### PR TITLE
Allow users to define their own kick-ban message

### DIFF
--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -86,30 +86,30 @@ public final class Channel {
 	 */
 	public void ban(final User user, final boolean kick) {
 		if (kick) {
-            ban(user, true, "Banned");
-        } else {
-            ban(user, false, null);
-        }
+	 	 	ban(user, true, "Banned");
+	 	} else {
+	 	 	ban(user, false, null);
+	 	}
 	}
 
-    /**
-     * Bans a user from this channel with an optional kick message.
-     *
-     * @param user The User to ban from this channel.
-     * @param kick Whether to kick this user after banning
-     * @param reason The message to append to the kick sent to the user.
-     */
-    public void ban(final User user, final boolean kick, final String reason) {
-        if (user.getHostName() != null) {
-            this.setMode("+b *!*@*" + user.getHostName());
-        } else {
-            this.setMode("+b " + user.getNick() + "!*@*");
-        }
+	/**
+	 * Bans a user from this channel with an optional kick message.
+	 *
+	 * @param user The User to ban from this channel.
+	 * @param kick Whether to kick this user after banning
+	 * @param reason The message to append to the kick sent to the user.
+	 */
+	public void ban(final User user, final boolean kick, final String reason) {
+	 	if (user.getHostName() != null) {
+	 	 	this.setMode("+b *!*@*" + user.getHostName());
+	 	} else {
+	 	 	this.setMode("+b " + user.getNick() + "!*@*");
+	 	}
 
-        if (kick) {
-            this.kick(user, reason);
-        }
-    }
+	 	if (kick) {
+	 	 	this.kick(user, reason);
+	 	  }
+	 }
 
 	/**
 	 * Changes the topic of this channel. Note that you need

--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -85,11 +85,7 @@ public final class Channel {
 	 * @param kick Whether to kick this user after banning.
 	 */
 	public void ban(final User user, final boolean kick) {
-		if (kick) {
-	 	 	ban(user, true, "Banned");
-	 	} else {
-	 	 	ban(user, false, null);
-	 	}
+	 	 ban(user, false, null);
 	}
 
 	/**
@@ -107,8 +103,12 @@ public final class Channel {
 	 	}
 
 	 	if (kick) {
-	 	 	this.kick(user, reason);
-	 	  }
+			if (reason == null) {
+				this.kick(user, "Banned");
+			} else {
+	 			this.kick(user, reason);
+		  }
+	 	}
 	 }
 
 	/**

--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -96,20 +96,20 @@ public final class Channel {
 	 * @param reason The message to append to the kick sent to the user.
 	 */
 	public void ban(final User user, final boolean kick, final String reason) {
-	 	if (user.getHostName() != null) {
-	 	 	this.setMode("+b *!*@*" + user.getHostName());
-	 	} else {
-	 	 	this.setMode("+b " + user.getNick() + "!*@*");
-	 	}
+		if (user.getHostName() != null) {
+			this.setMode("+b *!*@*" + user.getHostName());
+		} else {
+			this.setMode("+b " + user.getNick() + "!*@*");
+		}
 
 	 	if (kick) {
 			if (reason == null) {
 				this.kick(user, "Banned");
 			} else {
 	 			this.kick(user, reason);
-		  }
-	 	}
-	 }
+			}
+		}
+	}
 
 	/**
 	 * Changes the topic of this channel. Note that you need

--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -85,17 +85,32 @@ public final class Channel {
 	 * @param kick Whether to kick this user after banning.
 	 */
 	public void ban(final User user, final boolean kick) {
-		if (user.getHostName() != null) {
-			this.setMode("+b *!*@*" + user.getHostName());
-		} else {
-			this.setMode("+b " + user.getNick() + "!*@*");
-		}
-		// kick if requested
 		if (kick) {
-			this.kick(user, "Banned");
-		}
+            ban(user, true, "Banned");
+        } else {
+            ban(user, false, null);
+        }
 	}
-	
+
+    /**
+     * Bans a user from this channel with an optional kick message.
+     *
+     * @param user The User to ban from this channel.
+     * @param kick Whether to kick this user after banning
+     * @param reason The message to append to the kick sent to the user.
+     */
+    public void ban(final User user, final boolean kick, final String reason) {
+        if (user.getHostName() != null) {
+            this.setMode("+b *!*@*" + user.getHostName());
+        } else {
+            this.setMode("+b " + user.getNick() + "!*@*");
+        }
+
+        if (kick) {
+            this.kick(user, reason);
+        }
+    }
+
 	/**
 	 * Changes the topic of this channel. Note that you need
 	 * privileges to do this.


### PR DESCRIPTION
Allows users to define their own kick-ban message. Should be backwards compatible with previous releases.
