### PR TITLE
Reformatted README for GitHub markdown

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,15 @@
+# sIRC
 Sorcix Lib-IRC (sIRC) is a simple IRC library for Java.
 
-== Source Code ==
+---
+
+### Source Code
 
 The source code is in my git repository on Github:
 
-→ http://github.com/sorcix/sIRC
+- http://github.com/sorcix/sIRC
 
-== Maven ==
+### Maven
 
 ```
 <dependency>
@@ -15,22 +18,19 @@ The source code is in my git repository on Github:
     <version>1.1.5</version>
 </dependency>
 ```
+### Support
 
-== Support ==
-
-As sIRC contains about everything I needed, I'm not spending much
-time on it anymore. However, if you encounter a bug, or have a feature
-request, don't hesitate to let me know.
+As sIRC contains about everything I needed, I'm not spending much time on it anymore. However, if you encounter a bug, or have a feature request, don't hesitate to let me know.
 
 Use the sIRC issues page
 
-→ http://github.com/sorcix/sIRC/issues
+- http://github.com/sorcix/sIRC/issues
 
 Or send me an e-mail
 
-→ vic@demuzere.be
+- vic@demuzere.be
 
-==
+---
 
 Thanks for your interest in sIRC!
 If you're using it somewhere, let me know. :)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# sIRC
+Sorcix Lib-IRC (sIRC) is a simple IRC library for Java.
+
+---
+
+### Source Code
+
+The source code is in my git repository on Github:
+
+- http://github.com/sorcix/sIRC
+
+### Maven
+
+```
+<dependency>
+    <groupId>com.sorcix</groupId>
+    <artifactId>sirc</artifactId>
+    <version>1.1.5</version>
+</dependency>
+```
+### Support
+
+As sIRC contains about everything I needed, I'm not spending much time on it anymore. However, if you encounter a bug, or have a feature request, don't hesitate to let me know.
+
+Use the sIRC issues page
+
+- http://github.com/sorcix/sIRC/issues
+
+Or send me an e-mail
+
+- vic@demuzere.be
+
+---
+
+Thanks for your interest in sIRC!
+If you're using it somewhere, let me know. :)
+


### PR DESCRIPTION
Makes the README look a little nicer on GitHub.

In the changes, two files are shown. The first shows what edits I made to the original file, the second appears as the first file was `deleted` as the file was changed to markdown format.
