### PR TITLE
Test against oraclejdk8 to future-proof.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@ jdk:
   - oraclejdk7
   - openjdk7
   - openjdk6
+  - oraclejdk8
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - jdk: oraclejdk8
+

--- a/src/main/java/com/sorcix/sirc/IrcConnection.java
+++ b/src/main/java/com/sorcix/sirc/IrcConnection.java
@@ -27,20 +27,17 @@
  */
 package com.sorcix.sirc;
 
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
-
-import javax.net.SocketFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Main IRC Connection class in sIRC.
@@ -224,6 +221,8 @@ public class IrcConnection {
 	/**
 	 * Send a raw command to the IRC server.  Unrecognized responses
 	 * are passed to the AdvancedListener's onUnknown() callback.
+	 *
+	 * @param line The raw line to send.
 	 */
 	public void sendRaw(final String line) {
 		this.out.send(line);
@@ -281,7 +280,8 @@ public class IrcConnection {
 	/**
 	 * Connect to the IRC server. You must set the server details and nickname
 	 * before calling this method!
-	 * 
+	 *
+	 * @param sslctx The SSLContext to use.
 	 * @throws UnknownHostException
 	 *             When the domain name is invalid.
 	 * @throws IOException
@@ -310,7 +310,8 @@ public class IrcConnection {
 	/**
 	 * Connect to the IRC server. You must set the server details and nickname
 	 * before calling this method!
-	 * 
+	 *
+	 * @param sfact The SocketFactory to create a socket with.
 	 * @throws UnknownHostException
 	 *             When the domain name is invalid.
 	 * @throws IOException
@@ -342,7 +343,8 @@ public class IrcConnection {
 	/**
 	 * Connect to the IRC server. You must set the server details and nickname
 	 * before calling this method!
-	 * 
+	 *
+	 * @param sock The socket to connect to.
 	 * @throws UnknownHostException
 	 *             When the domain name is invalid.
 	 * @throws IOException

--- a/src/main/java/com/sorcix/sirc/ServerListener.java
+++ b/src/main/java/com/sorcix/sirc/ServerListener.java
@@ -83,6 +83,7 @@ public interface ServerListener {
 	 * @param channel The channel in which the user was kicked.
 	 * @param sender The user who kicked the user.
 	 * @param user The user who was kicked.
+	 * @param msg The kick message.
 	 */
 	void onKick(IrcConnection irc, Channel channel, User sender, User user, String msg);
 	

--- a/src/main/java/com/sorcix/sirc/User.java
+++ b/src/main/java/com/sorcix/sirc/User.java
@@ -90,6 +90,7 @@ public final class User {
 	 * @param nick The nickname.
 	 * @param user The username.
 	 * @param host The hostname.
+	 * @param realName The 'real name'.
 	 * @param irc The IrcConnection used to send messages to this
 	 *            user.
 	 */


### PR DESCRIPTION
Use Travis-CI to test the beta oraclejdk8 release in order to future-proof the project to some extent. Failure of this test will not affect the overall build status.
