### PR TITLE
Removes use of deprecated methods

### DIFF
--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -118,7 +118,7 @@ public final class Channel {
 	 * @param topic The new topic.
 	 */
 	public void changeTopic(final String topic) {
-		irc.getOutput().send("TOPIC " + getName() + " :" + topic);
+		irc.getOutput().send(new IrcPacket(null, "TOPIC", getName(), topic));
 	}
 	
 	@Override
@@ -277,7 +277,7 @@ public final class Channel {
 	 * Attempts to join this channel.
 	 */
 	public void join() {
-		irc.getOutput().send("JOIN " + getName());
+		irc.getOutput().send(new IrcPacket(null, "JOIN", getName(), null));
 	}
 	
 	/**
@@ -286,7 +286,7 @@ public final class Channel {
 	 * @param password The password needed to join this channel.
 	 */
 	public void join(final String password) {
-		irc.getOutput().send("JOIN " + getName() + " " + password);
+		irc.getOutput().send(new IrcPacket(null, "JOIN", getName() + " " + password, null));
 	}
 	
 	/**
@@ -295,7 +295,7 @@ public final class Channel {
 	 * @param user The user to kick from this channel.
 	 */
 	public void kick(final User user) {
-		irc.getOutput().send("KICK " + getName() + " " + user.getNick());
+		kick(user, null); // Send null so IRC server uses default kick message.
 	}
 	
 	/**
@@ -305,14 +305,18 @@ public final class Channel {
 	 * @param reason The reason why this user was kicked.
 	 */
 	public void kick(final User user, final String reason) {
-		irc.getOutput().send("KICK " + getName() + " " + user.getNick() + " :" + reason);
+		irc.getOutput().send(new IrcPacket(null, "KICK", getName() + " " + user.getNick(), reason));
 	}
 	
 	/**
 	 * Attempts to leave/part this channel.
 	 */
 	public void part() {
-		irc.getOutput().send("PART " + getName());
+		part(null);
+	}
+
+	public void part(String reason) {
+		irc.getOutput().send(new IrcPacket(null, "PART", getName(), reason));
 	}
 	
 	/**
@@ -415,7 +419,7 @@ public final class Channel {
 	 * @param command Command to send.
 	 */
 	public void sendCtcp(final String command) {
-		irc.getOutput().send("PRIVMSG " + getName() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+		irc.getOutput().send(new IrcPacket(null, "PRIVMSG", getName(), IrcPacket.CTCP + command + IrcPacket.CTCP));
 	}
 	
 	/**
@@ -436,7 +440,7 @@ public final class Channel {
 	 * @param message The message to send.
 	 */
 	public void sendMessage(final String message) {
-		irc.getOutput().send("PRIVMSG " + getName() + " :" + message);
+		irc.getOutput().send(new IrcPacket(null, "PRIVMSG", getName(), message));
 	}
 	
 	/**
@@ -445,7 +449,7 @@ public final class Channel {
 	 * @param message The notice to send.
 	 */
 	public void sendNotice(final String message) {
-		irc.getOutput().send("NOTICE " + getName() + " :" + message);
+		irc.getOutput().send(new IrcPacket(null, "NOTICE", getName(), message));
 	}
 	
 	/**
@@ -474,7 +478,7 @@ public final class Channel {
 	 * @param mode The mode to change.
 	 */
 	public void setMode(final String mode) {
-		irc.getOutput().send("MODE " + getName() + " " + mode);
+		irc.getOutput().send(new IrcPacket(null, "MODE", getName() + " " + mode, null));
 	}
 	
 	/**

--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -61,9 +61,9 @@ public final class Channel {
 		this.name = name;
 		this.irc = irc;
 		if (global) {
-			this.users = new ConcurrentHashMap<String, User>(100, .75f, 2);
+			users = new ConcurrentHashMap<String, User>(100, .75f, 2);
 		} else {
-			this.users = null;
+			users = null;
 		}
 	}
 	
@@ -73,8 +73,8 @@ public final class Channel {
 	 * @param user The user to add.
 	 */
 	protected void addUser(final User user) {
-		if ((this.users != null) && !this.users.containsKey(user.getNickLower())) {
-			this.users.put(user.getNickLower(), user);
+		if ((users != null) && !users.containsKey(user.getNickLower())) {
+			users.put(user.getNickLower(), user);
 		}
 	}
 	
@@ -97,16 +97,16 @@ public final class Channel {
 	 */
 	public void ban(final User user, final boolean kick, final String reason) {
 		if (user.getHostName() != null) {
-			this.setMode("+b *!*@*" + user.getHostName());
+			setMode("+b *!*@*" + user.getHostName());
 		} else {
-			this.setMode("+b " + user.getNick() + "!*@*");
+			setMode("+b " + user.getNick() + "!*@*");
 		}
 
 	 	if (kick) {
 			if (reason == null) {
-				this.kick(user, "Banned");
+				kick(user, "Banned");
 			} else {
-	 			this.kick(user, reason);
+	 			kick(user, reason);
 			}
 		}
 	}
@@ -118,13 +118,14 @@ public final class Channel {
 	 * @param topic The new topic.
 	 */
 	public void changeTopic(final String topic) {
-		this.irc.getOutput().send("TOPIC " + this.getName() + " :" + topic);
+		irc.getOutput().send("TOPIC " + getName() + " :" + topic);
 	}
 	
 	@Override
 	public boolean equals(final Object channel) {
 		try {
-			return ((Channel) channel).getName().equalsIgnoreCase(this.name) && (this.irc != null && this.irc.equals(((Channel)channel).irc));
+			return ((Channel) channel).getName().equalsIgnoreCase(name)
+					&& (irc != null && irc.equals(((Channel)channel).irc));
 		} catch (final Exception ex) {
 			return false;
 		}
@@ -132,7 +133,7 @@ public final class Channel {
 
 	@Override
 	public int hashCode() {
-		return this.name.hashCode();
+		return name.hashCode();
 	}
 	
 	/**
@@ -150,7 +151,7 @@ public final class Channel {
 	 * @return The topic.
 	 */
 	public String getTopic() {
-		return this.topic;
+		return topic;
 	}
 	
 	/**
@@ -165,11 +166,11 @@ public final class Channel {
 	 *         channel.
 	 */
 	protected User getUser(final String nickLower) {
-		return this.users.get(nickLower);
+		return users.get(nickLower);
 	}
 
 	public User getUs() {
-		return this.users.get(this.irc.getClient().getNickLower());
+		return users.get(irc.getClient().getNickLower());
 	}
 	
 	/**
@@ -188,7 +189,7 @@ public final class Channel {
 	 * @see #isGlobal()
 	 */
 	public Iterator<User> getUsers() {
-		return this.users.values().iterator();
+		return users.values().iterator();
 	}
 	
 	/**
@@ -199,7 +200,7 @@ public final class Channel {
 	 * @since 1.0.0
 	 */
 	public void giveAdmin(final User user) {
-		this.setMode(User.MODE_ADMIN, user, true);
+		setMode(User.MODE_ADMIN, user, true);
 	}
 	
 	/**
@@ -210,7 +211,7 @@ public final class Channel {
 	 * @since 1.0.0
 	 */
 	public void giveFounder(final User user) {
-		this.setMode(User.MODE_FOUNDER, user, true);
+		setMode(User.MODE_FOUNDER, user, true);
 	}
 	
 	/**
@@ -221,7 +222,7 @@ public final class Channel {
 	 * @param user The user to give halfop privileges.
 	 */
 	public void giveHalfop(final User user) {
-		this.setMode(User.MODE_HALF_OP, user, true);
+		setMode(User.MODE_HALF_OP, user, true);
 	}
 	
 	/**
@@ -230,7 +231,7 @@ public final class Channel {
 	 * @param user The user to give operator privileges.
 	 */
 	public void giveOperator(final User user) {
-		this.setMode(User.MODE_OPERATOR, user, true);
+		setMode(User.MODE_OPERATOR, user, true);
 	}
 	
 	/**
@@ -239,7 +240,7 @@ public final class Channel {
 	 * @param user The user to give voice privileges.
 	 */
 	public void giveVoice(final User user) {
-		this.setMode(User.MODE_VOICE, user, true);
+		setMode(User.MODE_VOICE, user, true);
 	}
 	
 	/**
@@ -249,7 +250,7 @@ public final class Channel {
 	 * @return True if given user is in this channel, false otherwise.
 	 */
 	public boolean hasUser(final String nick) {
-		return (this.users != null) && this.users.containsKey(nick.toLowerCase());
+		return (users != null) && users.containsKey(nick.toLowerCase());
 	}
 	
 	/**
@@ -259,7 +260,7 @@ public final class Channel {
 	 * @return True if given user is in this channel, false otherwise.
 	 */
 	public boolean hasUser(final User user) {
-		return this.hasUser(user.getNickLower());
+		return hasUser(user.getNickLower());
 	}
 	
 	/**
@@ -269,14 +270,14 @@ public final class Channel {
 	 * @return True if this channel object is shared.
 	 */
 	public boolean isGlobal() {
-		return this.users != null;
+		return users != null;
 	}
 	
 	/**
 	 * Attempts to join this channel.
 	 */
 	public void join() {
-		this.irc.getOutput().send("JOIN " + this.getName());
+		irc.getOutput().send("JOIN " + getName());
 	}
 	
 	/**
@@ -285,7 +286,7 @@ public final class Channel {
 	 * @param password The password needed to join this channel.
 	 */
 	public void join(final String password) {
-		this.irc.getOutput().send("JOIN " + this.getName() + " " + password);
+		irc.getOutput().send("JOIN " + getName() + " " + password);
 	}
 	
 	/**
@@ -294,7 +295,7 @@ public final class Channel {
 	 * @param user The user to kick from this channel.
 	 */
 	public void kick(final User user) {
-		this.irc.getOutput().send("KICK " + this.getName() + " " + user.getNick());
+		irc.getOutput().send("KICK " + getName() + " " + user.getNick());
 	}
 	
 	/**
@@ -304,14 +305,14 @@ public final class Channel {
 	 * @param reason The reason why this user was kicked.
 	 */
 	public void kick(final User user, final String reason) {
-		this.irc.getOutput().send("KICK " + this.getName() + " " + user.getNick() + " :" + reason);
+		irc.getOutput().send("KICK " + getName() + " " + user.getNick() + " :" + reason);
 	}
 	
 	/**
 	 * Attempts to leave/part this channel.
 	 */
 	public void part() {
-		this.irc.getOutput().send("PART " + this.getName());
+		irc.getOutput().send("PART " + getName());
 	}
 	
 	/**
@@ -321,7 +322,7 @@ public final class Channel {
 	 * @since 1.0.0
 	 */
 	public void removeAdmin(final User user) {
-		this.setMode(User.MODE_ADMIN, user, false);
+		setMode(User.MODE_ADMIN, user, false);
 	}
 	
 	/**
@@ -331,7 +332,7 @@ public final class Channel {
 	 * @since 1.0.0
 	 */
 	public void removeFounder(final User user) {
-		this.setMode(User.MODE_FOUNDER, user, false);
+		setMode(User.MODE_FOUNDER, user, false);
 	}
 	
 	/**
@@ -341,7 +342,7 @@ public final class Channel {
 	 * @since 1.0.0
 	 */
 	public void removeHalfop(final User user) {
-		this.setMode(User.MODE_HALF_OP, user, false);
+		setMode(User.MODE_HALF_OP, user, false);
 	}
 	
 	/**
@@ -350,7 +351,7 @@ public final class Channel {
 	 * @param user The user to remove operator privileges from.
 	 */
 	public void removeOperator(final User user) {
-		this.setMode(User.MODE_OPERATOR, user, false);
+		setMode(User.MODE_OPERATOR, user, false);
 	}
 	
 	/**
@@ -359,8 +360,8 @@ public final class Channel {
 	 * @param user The user to remove.
 	 */
 	protected void removeUser(final User user) {
-		if ((this.users != null) && this.users.containsKey(user.getNickLower())) {
-			this.users.remove(user.getNickLower());
+		if ((users != null) && users.containsKey(user.getNickLower())) {
+			users.remove(user.getNickLower());
 		}
 	}
 	
@@ -370,7 +371,7 @@ public final class Channel {
 	 * @param user The user to remove voice privileges from.
 	 */
 	public void removeVoice(final User user) {
-		this.setMode(User.MODE_VOICE, user, false);
+		setMode(User.MODE_VOICE, user, false);
 	}
 	
 	/**
@@ -380,11 +381,11 @@ public final class Channel {
 	 * @param neww The new nickname.
 	 */
 	protected void renameUser(final String old, final String neww) {
-		if ((this.users != null) && this.users.containsKey(old)) {
-			final User user = this.users.get(old);
-			this.users.remove(old);
+		if ((users != null) && users.containsKey(old)) {
+			final User user = users.get(old);
+			users.remove(old);
 			user.setNick(neww);
-			this.users.put(user.getNickLower(), user);
+			users.put(user.getNickLower(), user);
 		}
 	}
 	
@@ -395,7 +396,7 @@ public final class Channel {
 	 * @see #sendMessage(String)
 	 */
 	public void send(final String message) {
-		this.sendMessage(message);
+		sendMessage(message);
 	}
 	
 	/**
@@ -404,7 +405,7 @@ public final class Channel {
 	 * @param action The action to send.
 	 */
 	public void sendAction(final String action) {
-		this.sendCtcpAction(action);
+		sendCtcpAction(action);
 	}
 	
 	/**
@@ -414,7 +415,7 @@ public final class Channel {
 	 * @param command Command to send.
 	 */
 	public void sendCtcp(final String command) {
-		this.irc.getOutput().send("PRIVMSG " + this.getName() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+		irc.getOutput().send("PRIVMSG " + getName() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
 	}
 	
 	/**
@@ -425,7 +426,7 @@ public final class Channel {
 	 */
 	protected void sendCtcpAction(final String action) {
 		if ((action != null) && (action.length() != 0)) {
-			this.sendCtcp("ACTION " + action);
+			sendCtcp("ACTION " + action);
 		}
 	}
 	
@@ -435,7 +436,7 @@ public final class Channel {
 	 * @param message The message to send.
 	 */
 	public void sendMessage(final String message) {
-		this.irc.getOutput().send("PRIVMSG " + this.getName() + " :" + message);
+		irc.getOutput().send("PRIVMSG " + getName() + " :" + message);
 	}
 	
 	/**
@@ -444,7 +445,7 @@ public final class Channel {
 	 * @param message The notice to send.
 	 */
 	public void sendNotice(final String message) {
-		this.irc.getOutput().send("NOTICE " + this.getName() + " :" + message);
+		irc.getOutput().send("NOTICE " + getName() + " :" + message);
 	}
 	
 	/**
@@ -456,9 +457,9 @@ public final class Channel {
 	 */
 	public void setMode(final char mode, final User user, final boolean toggle) {
 		if (toggle) {
-			this.setMode("+" + mode + " " + user.getNick());
+			setMode("+" + mode + " " + user.getNick());
 		} else {
-			this.setMode("-" + mode + " " + user.getNick());
+			setMode("-" + mode + " " + user.getNick());
 		}
 	}
 	
@@ -473,7 +474,7 @@ public final class Channel {
 	 * @param mode The mode to change.
 	 */
 	public void setMode(final String mode) {
-		this.irc.getOutput().send("MODE " + this.getName() + " " + mode);
+		irc.getOutput().send("MODE " + getName() + " " + mode);
 	}
 	
 	/**
@@ -489,7 +490,7 @@ public final class Channel {
 	
 	@Override
 	public String toString() {
-		return this.getName();
+		return getName();
 	}
 	
 	/**
@@ -502,14 +503,14 @@ public final class Channel {
 	 * @return The updated shared User object.
 	 */
 	protected User updateUser(final User user, final boolean createNew) {
-		if (this.hasUser(user.getNickLower())) {
+		if (hasUser(user.getNickLower())) {
 			// update user if it exists
-			final User shared = this.getUser(user.getNickLower());
+			final User shared = getUser(user.getNickLower());
 			shared.updateUser(user);
 			return shared;
 		} else if (createNew) {
 			// create a new one
-			this.addUser(user);
+			addUser(user);
 			return user;
 		}
 		return null;

--- a/src/main/java/com/sorcix/sirc/ClientState.java
+++ b/src/main/java/com/sorcix/sirc/ClientState.java
@@ -51,8 +51,8 @@ public final class ClientState {
 	 * Creates a new ClientState.
 	 */
 	protected ClientState() {
-		this.channels = new HashMap<String, Channel>();
-		this.users = new HashMap<String, User>();
+		channels = new HashMap<String, Channel>();
+		users = new HashMap<String, User>();
 	}
 
 	/**
@@ -62,8 +62,8 @@ public final class ClientState {
 	 *            The channel to add.
 	 */
 	protected void addChannel(final Channel channel) {
-		if (!this.channels.containsKey(channel.getName().toLowerCase())) {
-			this.channels.put(channel.getName().toLowerCase(), channel);
+		if (!channels.containsKey(channel.getName().toLowerCase())) {
+			channels.put(channel.getName().toLowerCase(), channel);
 		}
 	}
 
@@ -74,8 +74,8 @@ public final class ClientState {
 	 *            The user to add.
 	 */
 	protected void addUser(final User user) {
-		if (!this.users.containsKey(user.getNickLower())) {
-			this.users.put(user.getNickLower(), user);
+		if (!users.containsKey(user.getNickLower())) {
+			users.put(user.getNickLower(), user);
 		}
 	}
 
@@ -89,7 +89,7 @@ public final class ClientState {
 	 * @see #getChannel(String)
 	 */
 	protected Channel getChannel(final Channel channel) {
-		return this.getChannel(channel.getName());
+		return getChannel(channel.getName());
 	}
 
 	/**
@@ -101,8 +101,8 @@ public final class ClientState {
 	 *         user is not in that channel)
 	 */
 	protected Channel getChannel(final String channel) {
- 		if (channel != null && this.channels.containsKey(channel.toLowerCase())) {
-			return this.channels.get(channel.toLowerCase());
+ 		if (channel != null && channels.containsKey(channel.toLowerCase())) {
+			return channels.get(channel.toLowerCase());
 		}
 		return null;
 	}
@@ -113,7 +113,7 @@ public final class ClientState {
 	 * @return an iterator through all Channels.
 	 */
 	public Iterator<Channel> getChannels() {
-		return this.channels.values().iterator();
+		return channels.values().iterator();
 	}
 
 	/**
@@ -122,7 +122,7 @@ public final class ClientState {
 	 * @return The local {@code User}.
 	 */
 	public User getClient() {
-		return this.client;
+		return client;
 	}
 
 	/**
@@ -135,8 +135,8 @@ public final class ClientState {
 	 */
 	protected User getUser(final String nick) {
 		//TODO: implement singleton users in User, Channel and IrcConnection
-		if (this.users.containsKey(nick)) {
-			return this.users.get(nick);
+		if (users.containsKey(nick)) {
+			return users.get(nick);
 		}
 		return null;
 	}
@@ -149,14 +149,14 @@ public final class ClientState {
 	 * @return True if the channel is in the list, false otherwise.
 	 */
 	protected boolean hasChannel(final String name) {
-		return name != null && this.channels.containsKey(name.toLowerCase());
+		return name != null && channels.containsKey(name.toLowerCase());
 	}
 
 	/**
 	 * Remove all channels from the channel map.
 	 */
 	protected void removeAll() {
-		this.channels.clear();
+		channels.clear();
 	}
 
 	/**
@@ -166,8 +166,8 @@ public final class ClientState {
 	 *            The channel name.
 	 */
 	protected void removeChannel(final String channel) {
-		if (channel != null && this.channels.containsKey(channel.toLowerCase())) {
-			this.channels.remove(channel.toLowerCase());
+		if (channel != null && channels.containsKey(channel.toLowerCase())) {
+			channels.remove(channel.toLowerCase());
 		}
 	}
 
@@ -178,6 +178,6 @@ public final class ClientState {
 	 *            The local {@code User}.
 	 */
 	protected void setClient(final User user) {
-		this.client = user;
+		client = user;
 	}
 }

--- a/src/main/java/com/sorcix/sirc/IrcConnection.java
+++ b/src/main/java/com/sorcix/sirc/IrcConnection.java
@@ -222,10 +222,10 @@ public class IrcConnection {
 	 * Send a raw command to the IRC server.  Unrecognized responses
 	 * are passed to the AdvancedListener's onUnknown() callback.
 	 *
-	 * @param line The raw line to send.
+	 * @param packet The raw line to send.
 	 */
-	public void sendRaw(final String line) {
-		out.send(line);
+	public void sendRaw(final IrcPacket packet) {
+		out.send(packet);
 	}
 	
 	/**

--- a/src/main/java/com/sorcix/sirc/IrcConnection.java
+++ b/src/main/java/com/sorcix/sirc/IrcConnection.java
@@ -384,7 +384,7 @@ public class IrcConnection {
 		this.out.sendNowEx(IrcPacketFactory.createNICK(this.state.getClient()
 				.getNick()));
 		// wait for reply
-		String line = null;
+		String line;
 		loop: while ((line = this.in.getReader().readLine()) != null) {
 			IrcDebug.log(line);
 			final IrcPacket decoder = new IrcPacket(line, this);
@@ -397,7 +397,7 @@ public class IrcConnection {
 						final String nick = decoder.getArgumentsArray()[0];
 						if (!this.state.getClient().getNick().equals(nick))
 							this.setNick(nick);
-					}; break;
+					} break;
 				case 4: // login OK
 					break loop;
 				case 432:

--- a/src/main/java/com/sorcix/sirc/IrcConnection.java
+++ b/src/main/java/com/sorcix/sirc/IrcConnection.java
@@ -133,11 +133,11 @@ public class IrcConnection {
 	public IrcConnection(final String server, final int port,
 			final String password) {
 		this.server = new IrcServer(server, port, password, false);
-		this.serverListeners = new Vector<ServerListener>(4);
-		this.messageListeners = new Vector<MessageListener>(4);
-		this.modeListeners = new Vector<ModeListener>(2);
-		this.services = new Vector<SIRCService>(0);
-		this.state = new ClientState();
+		serverListeners = new Vector<ServerListener>(4);
+		messageListeners = new Vector<MessageListener>(4);
+		modeListeners = new Vector<ModeListener>(2);
+		services = new Vector<SIRCService>(0);
+		state = new ClientState();
 	}
 
 	/**
@@ -159,8 +159,8 @@ public class IrcConnection {
 	 *            The message listener to add.
 	 */
 	public void addMessageListener(final MessageListener listener) {
-		if ((listener != null) && !this.messageListeners.contains(listener)) {
-			this.messageListeners.add(listener);
+		if ((listener != null) && !messageListeners.contains(listener)) {
+			messageListeners.add(listener);
 		}
 	}
 
@@ -175,8 +175,8 @@ public class IrcConnection {
 	 *            The mode listener to add.
 	 */
 	public void addModeListener(final ModeListener listener) {
-		if ((listener != null) && !this.modeListeners.contains(listener)) {
-			this.modeListeners.add(listener);
+		if ((listener != null) && !modeListeners.contains(listener)) {
+			modeListeners.add(listener);
 		}
 	}
 
@@ -187,8 +187,8 @@ public class IrcConnection {
 	 *            The server listener to add.
 	 */
 	public void addServerListener(final ServerListener listener) {
-		if ((listener != null) && !this.serverListeners.contains(listener)) {
-			this.serverListeners.add(listener);
+		if ((listener != null) && !serverListeners.contains(listener)) {
+			serverListeners.add(listener);
 		}
 	}
 
@@ -201,8 +201,8 @@ public class IrcConnection {
 	 *            The service to add.
 	 */
 	public void addService(final SIRCService service) {
-		if ((service != null) && !this.services.contains(service)) {
-			this.services.add(service);
+		if ((service != null) && !services.contains(service)) {
+			services.add(service);
 			service.load(this);
 		}
 	}
@@ -215,7 +215,7 @@ public class IrcConnection {
 	 * @since 1.0.2
 	 */
 	public void askMotd() {
-		this.out.send(IrcPacketFactory.createMOTD());
+		out.send(IrcPacketFactory.createMOTD());
 	}
 
 	/**
@@ -225,7 +225,7 @@ public class IrcConnection {
 	 * @param line The raw line to send.
 	 */
 	public void sendRaw(final String line) {
-		this.out.send(line);
+		out.send(line);
 	}
 	
 	/**
@@ -235,7 +235,7 @@ public class IrcConnection {
 	 *            The channel to request the userlist for.
 	 */
 	protected void askNames(final Channel channel) {
-		this.out.send(IrcPacketFactory.createNAMES(channel.getName()));
+		out.send(IrcPacketFactory.createNAMES(channel.getName()));
 	}
 
 	/**
@@ -243,15 +243,15 @@ public class IrcConnection {
 	 */
 	private void close() {
 		try {
-			this.in.interrupt();
-			this.out.interrupt();
+			in.interrupt();
+			out.interrupt();
 			// close input stream
-			this.in.close();
+			in.close();
 			// close output stream
-			this.out.close();
+			out.close();
 			// close socket
-			if (this.socket.isConnected()) {
-				this.socket.close();
+			if (socket.isConnected()) {
+				socket.close();
 			}
 		} catch (final Exception ex) {
 			// ignore
@@ -274,7 +274,7 @@ public class IrcConnection {
 	 * @see #setNick(String)
 	 */
 	public void connect() throws UnknownHostException, IOException, NickNameException, PasswordException {
-		this.connect((SSLContext) null);
+		connect((SSLContext) null);
 	}
 	
 	/**
@@ -294,16 +294,16 @@ public class IrcConnection {
 	 * @see #setNick(String)
 	 */
 	public void connect(SSLContext sslctx) throws UnknownHostException, IOException, NickNameException, PasswordException {
-		if (this.server.isSecure()) {
+		if (server.isSecure()) {
 			try {
 				if (sslctx == null)
 					sslctx = SSLContext.getDefault();
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
-			this.connect(sslctx.getSocketFactory());
+			connect(sslctx.getSocketFactory());
 		} else {
-			this.connect(SocketFactory.getDefault());
+			connect(SocketFactory.getDefault());
 		}
 	}
 
@@ -325,16 +325,16 @@ public class IrcConnection {
 	 */
 	public void connect(SocketFactory sfact) throws UnknownHostException, IOException, NickNameException, PasswordException {
 		// check if a server is given
-		if ((this.server.getAddress() == null)) {
+		if ((server.getAddress() == null)) {
 			throw new IOException("Server address is not set!");
 		}
 		// connect socket
-		if (this.socket == null || !this.socket.isConnected()) {
-			Socket socket = sfact.createSocket(this.server.getAddress(), this.server.getPort());
-			this.socket = null;
-			this.connect(socket);
-		} else if (this.socket != null) {
-			this.connect(this.socket);
+		if (socket == null || !socket.isConnected()) {
+			Socket socket = sfact.createSocket(server.getAddress(), server.getPort());
+			socket = null;
+			connect(socket);
+		} else if (socket != null) {
+			connect(socket);
 		} else {
 			throw new IllegalStateException("invalid socket state");
 		}
@@ -360,32 +360,32 @@ public class IrcConnection {
 	public void connect(Socket sock) throws UnknownHostException, IOException, NickNameException, PasswordException {
 		boolean reconnecting = true;
 		// don't even try if nickname is empty
-		if ((this.state.getClient() == null) || this.state.getClient().getNick().trim().equals("")) {
+		if ((state.getClient() == null) || state.getClient().getNick().trim().equals("")) {
 			throw new NickNameException("Nickname is empty or null!");
 		}
 		// allows for handling SASL, etc. before doing IRC handshake
 		// set to input socket
-		if (sock != null && this.socket != sock) {
-			this.socket = sock;
+		if (sock != null && socket != sock) {
+			socket = sock;
 			reconnecting = false;
 		}
 		// open streams
-		this.out = new IrcOutput(this, new OutputStreamWriter(this.socket.getOutputStream(), this.charset));
-		this.in = new IrcInput(this, new InputStreamReader(this.socket.getInputStream(), this.charset));
+		out = new IrcOutput(this, new OutputStreamWriter(socket.getOutputStream(), charset));
+		in = new IrcInput(this, new InputStreamReader(socket.getInputStream(), charset));
 		if (!reconnecting) {
 			// send password if given
-			if (this.server.getPassword() != null) {
-				this.out.sendNowEx(IrcPacketFactory.createPASS(this.server
+			if (server.getPassword() != null) {
+				out.sendNowEx(IrcPacketFactory.createPASS(server
 						.getPassword()));
 			}
-			this.out.sendNowEx(IrcPacketFactory.createUSER(this.state.getClient()
-					.getUserName(), this.state.getClient().getNick()));
+			out.sendNowEx(IrcPacketFactory.createUSER(state.getClient()
+					.getUserName(), state.getClient().getNick()));
 		}
-		this.out.sendNowEx(IrcPacketFactory.createNICK(this.state.getClient()
+		out.sendNowEx(IrcPacketFactory.createNICK(state.getClient()
 				.getNick()));
 		// wait for reply
 		String line;
-		loop: while ((line = this.in.getReader().readLine()) != null) {
+		loop: while ((line = in.getReader().readLine()) != null) {
 			IrcDebug.log(line);
 			final IrcPacket decoder = new IrcPacket(line, this);
 			if (decoder.isNumeric()) {
@@ -395,34 +395,34 @@ public class IrcConnection {
 				case 2:
 				case 3: {
 						final String nick = decoder.getArgumentsArray()[0];
-						if (!this.state.getClient().getNick().equals(nick))
-							this.setNick(nick);
+						if (!state.getClient().getNick().equals(nick))
+							setNick(nick);
 					} break;
 				case 4: // login OK
 					break loop;
 				case 432:
 				case 433: {
 						// bad/in-use nickname nickname
-						throw new NickNameException("Nickname " + this.state.getClient().getNick() + " already in use or not allowed!");
+						throw new NickNameException("Nickname " + state.getClient().getNick() + " already in use or not allowed!");
 					} // break; unnecessary due to throw
 				case 464: {
 						// wrong password
-						this.disconnect();
+						disconnect();
 						throw new PasswordException("Invalid password");
 					} // break; unnecessary due to throw
 				}
 			}
 			if (line.startsWith("PING ")) {
-				this.out.pong(line.substring(5));
+				out.pong(line.substring(5));
 			}
 		}
 		// start listening
-		this.in.start();
-		this.out.start();
+		in.start();
+		out.start();
 		// we are connected
-		this.setConnected(true);
+		setConnected(true);
 		// send events
-		for (final Iterator<ServerListener> it = this.getServerListeners(); it
+		for (final Iterator<ServerListener> it = getServerListeners(); it
 				.hasNext();) {
 			it.next().onConnect(this);
 		}
@@ -444,8 +444,8 @@ public class IrcConnection {
 		if (Channel.CHANNEL_PREFIX.indexOf(name.charAt(0)) < 0) {
 			name = "#" + name;
 		}
-		if (this.getState().hasChannel(name)) {
-			return this.getState().getChannel(name);
+		if (getState().hasChannel(name)) {
+			return getState().getChannel(name);
 		} else {
 			return new Channel(name, this, false);
 		}
@@ -477,10 +477,10 @@ public class IrcConnection {
 	 * @return A {@code User} object representing given user.
 	 */
 	public User createUser(final String nick, final String channel) {
-		final User empty = this.createUser(nick);
-		if (this.getState().hasChannel(channel)
-				&& this.getState().getChannel(channel).hasUser(nick)) {
-			return this.getState().getChannel(channel).getUser(nick);
+		final User empty = createUser(nick);
+		if (getState().hasChannel(channel)
+				&& getState().getChannel(channel).hasUser(nick)) {
+			return getState().getChannel(channel).getUser(nick);
 		} else {
 			return empty;
 		}
@@ -492,7 +492,7 @@ public class IrcConnection {
 	 * disconnect us.
 	 */
 	public void disconnect() {
-		this.disconnect(null);
+		disconnect(null);
 	}
 
 	/**
@@ -504,12 +504,12 @@ public class IrcConnection {
 	 *            The QUIT message to use.
 	 */
 	public void disconnect(final String message) {
-		if (this.isConnected()) {
-			this.out.sendNow(IrcPacketFactory.createQUIT(message));
+		if (isConnected()) {
+			out.sendNow(IrcPacketFactory.createQUIT(message));
 		} else {
-			this.close();
-			this.getState().removeAll();
-			this.garbageCollection();
+			close();
+			getState().removeAll();
+			garbageCollection();
 		}
 	}
 
@@ -528,7 +528,7 @@ public class IrcConnection {
 	 * @return The advanced listener, or null.
 	 */
 	protected AdvancedListener getAdvancedListener() {
-		return this.advancedListener;
+		return advancedListener;
 	}
 
 	/**
@@ -537,7 +537,7 @@ public class IrcConnection {
 	 * @return All channels we're currently in.
 	 */
 	public Iterator<Channel> getChannels() {
-		return this.getState().getChannels();
+		return getState().getChannels();
 	}
 
 	/**
@@ -548,7 +548,7 @@ public class IrcConnection {
 	 * @return The character set for the connection's encoding.
 	 */
 	public Charset getCharset() {
-		return this.charset;
+		return charset;
 	}
 
 	/**
@@ -557,7 +557,7 @@ public class IrcConnection {
 	 * @return User representing this client.
 	 */
 	public User getClient() {
-		return this.state.getClient();
+		return state.getClient();
 	}
 
 	/**
@@ -566,7 +566,7 @@ public class IrcConnection {
 	 * @return Outgoing message delay in milliseconds.
 	 */
 	public int getMessageDelay() {
-		return this.messageDelay;
+		return messageDelay;
 	}
 
 	/**
@@ -575,7 +575,7 @@ public class IrcConnection {
 	 * @return All {@code MessageListeners}.
 	 */
 	protected Iterator<MessageListener> getMessageListeners() {
-		return this.messageListeners.iterator();
+		return messageListeners.iterator();
 	}
 
 	/**
@@ -584,7 +584,7 @@ public class IrcConnection {
 	 * @return All {@code ModeListeners}.
 	 */
 	protected Iterator<ModeListener> getModeListeners() {
-		return this.modeListeners.iterator();
+		return modeListeners.iterator();
 	}
 
 	/**
@@ -594,7 +594,7 @@ public class IrcConnection {
 	 * @return The {@code IrcOutput} used to send messages.
 	 */
 	protected IrcOutput getOutput() {
-		return this.out;
+		return out;
 	}
 
 	/**
@@ -603,7 +603,7 @@ public class IrcConnection {
 	 * @return The IRC server.
 	 */
 	public IrcServer getServer() {
-		return this.server;
+		return server;
 	}
 
 	/**
@@ -613,7 +613,7 @@ public class IrcConnection {
 	 * @since 1.0.0
 	 */
 	public String getServerAddress() {
-		return this.server.getAddress();
+		return server.getAddress();
 	}
 
 	/**
@@ -622,7 +622,7 @@ public class IrcConnection {
 	 * @return All {@code ServerListeners}.
 	 */
 	protected Iterator<ServerListener> getServerListeners() {
-		return this.serverListeners.iterator();
+		return serverListeners.iterator();
 	}
 
 	/**
@@ -632,7 +632,7 @@ public class IrcConnection {
 	 * @since 1.0.0
 	 */
 	public int getServerPort() {
-		return this.server.getPort();
+		return server.getPort();
 	}
 
 	/**
@@ -641,7 +641,7 @@ public class IrcConnection {
 	 * @return All running services.
 	 */
 	private Iterator<SIRCService> getServices() {
-		return this.services.iterator();
+		return services.iterator();
 	}
 
 	/**
@@ -651,7 +651,7 @@ public class IrcConnection {
 	 * @since 1.1.0
 	 */
 	public ClientState getState() {
-		return this.state;
+		return state;
 	}
 
 	/**
@@ -661,8 +661,8 @@ public class IrcConnection {
 	 * @since 0.9.4
 	 */
 	protected String getVersion() {
-		if (this.version != null) {
-			return this.version;
+		if (version != null) {
+			return version;
 		}
 		return IrcConnection.ABOUT;
 	}
@@ -673,7 +673,7 @@ public class IrcConnection {
 	 * @return {@code true} if redirection is allowed, {@code false} otherwise.
 	 */
 	public boolean isBounceAllowed() {
-		return this.bounceAllowed;
+		return bounceAllowed;
 	}
 
 	/**
@@ -682,7 +682,7 @@ public class IrcConnection {
 	 * @return True if the client is connected, false otherwise.
 	 */
 	public boolean isConnected() {
-		return this.connected;
+		return connected;
 	}
 
 	/**
@@ -693,7 +693,7 @@ public class IrcConnection {
 	 * @return True if given {@code User} represents us, false otherwise.
 	 */
 	public boolean isUs(final User user) {
-		return user.equals(this.state.getClient());
+		return user.equals(state.getClient());
 	}
 
 	/**
@@ -702,7 +702,7 @@ public class IrcConnection {
 	 * @return True if this connection is using SSL, false otherwise.
 	 */
 	public boolean isUsingSSL() {
-		return this.server.isSecure();
+		return server.isSecure();
 	}
 
 	/**
@@ -711,10 +711,10 @@ public class IrcConnection {
 	 * @see #removeService(SIRCService)
 	 */
 	public void removeAllServices() {
-		if (this.services.size() > 0) {
-			for (final Iterator<SIRCService> it = this.getServices(); it
+		if (services.size() > 0) {
+			for (final Iterator<SIRCService> it = getServices(); it
 					.hasNext();) {
-				this.removeService(it.next());
+				removeService(it.next());
 			}
 		}
 	}
@@ -726,8 +726,8 @@ public class IrcConnection {
 	 *            The message listener to remove.
 	 */
 	public void removeMessageListener(final MessageListener listener) {
-		if ((listener != null) && this.messageListeners.contains(listener)) {
-			this.messageListeners.remove(listener);
+		if ((listener != null) && messageListeners.contains(listener)) {
+			messageListeners.remove(listener);
 		}
 	}
 
@@ -738,8 +738,8 @@ public class IrcConnection {
 	 *            The mode listener to remove.
 	 */
 	public void removeModeListener(final ModeListener listener) {
-		if ((listener != null) && this.modeListeners.contains(listener)) {
-			this.modeListeners.remove(listener);
+		if ((listener != null) && modeListeners.contains(listener)) {
+			modeListeners.remove(listener);
 		}
 	}
 
@@ -750,8 +750,8 @@ public class IrcConnection {
 	 *            The server listener to remove.
 	 */
 	public void removeServerListener(final ServerListener listener) {
-		if ((listener != null) && this.serverListeners.contains(listener)) {
-			this.serverListeners.remove(listener);
+		if ((listener != null) && serverListeners.contains(listener)) {
+			serverListeners.remove(listener);
 		}
 	}
 
@@ -764,9 +764,9 @@ public class IrcConnection {
 	 *            The service to remove.
 	 */
 	public void removeService(final SIRCService service) {
-		if ((service != null) && !this.services.contains(service)) {
+		if ((service != null) && !services.contains(service)) {
 			service.unload(this);
-			this.services.remove(service);
+			services.remove(service);
 		}
 	}
 
@@ -777,7 +777,7 @@ public class IrcConnection {
 	 *            The advanced listener to use, or {@code null}.
 	 */
 	public void setAdvancedListener(final AdvancedListener listener) {
-		this.advancedListener = listener;
+		advancedListener = listener;
 	}
 
 	/**
@@ -790,7 +790,7 @@ public class IrcConnection {
 	 * @since 1.0.2
 	 */
 	public void setAway(final String reason) {
-		this.out.send(IrcPacketFactory.createAWAY(reason));
+		out.send(IrcPacketFactory.createAWAY(reason));
 	}
 
 	/**
@@ -851,16 +851,16 @@ public class IrcConnection {
 	 *            New nickname.
 	 */
 	public void setNick(final String nick) {
-		if (!this.isConnected()) {
+		if (!isConnected()) {
 			if (nick != null) {
-				if (this.state.getClient() == null) {
-					this.state.setClient(new User(nick, "sIRC", null, null, this));
+				if (state.getClient() == null) {
+					state.setClient(new User(nick, "sIRC", null, null, this));
 					return;
 				}
-				this.state.getClient().setNick(nick);
+				state.getClient().setNick(nick);
 			}
 		} else {
-			this.out.sendNow(IrcPacketFactory.createNICK(nick));
+			out.sendNow(IrcPacketFactory.createNICK(nick));
 		}
 	}
 
@@ -868,10 +868,10 @@ public class IrcConnection {
 		setUsername(username, null);
 	}
 	public void setUsername(final String username, final String realname) {
-		if (!this.isConnected()) {
+		if (!isConnected()) {
 			if (username != null) {
-				if (this.state.getClient() == null) {
-					this.state.setClient(new User(null, username, null, realname, this));
+				if (state.getClient() == null) {
+					state.setClient(new User(null, username, null, realname, this));
 					return;
 				}
 			}
@@ -885,7 +885,7 @@ public class IrcConnection {
 	 * @since 1.0.2
 	 */
 	public void setNotAway() {
-		this.setAway(null);
+		setAway(null);
 	}
 
 	/**
@@ -895,7 +895,7 @@ public class IrcConnection {
 	 *            The server to connect to.
 	 */
 	public void setServer(final IrcServer server) {
-		if (!this.isConnected()) {
+		if (!isConnected()) {
 			this.server = server;
 		}
 	}
@@ -910,8 +910,8 @@ public class IrcConnection {
 	 * @since 1.0.0
 	 */
 	public void setServer(final String address, final int port) {
-		this.setServerAddress(address);
-		this.setServerPort(port);
+		setServerAddress(address);
+		setServerPort(port);
 	}
 
 	/**
@@ -922,8 +922,8 @@ public class IrcConnection {
 	 * @since 1.0.0
 	 */
 	public void setServerAddress(final String address) {
-		if (!this.isConnected() && (address != null)) {
-			this.server.setAddress(address);
+		if (!isConnected() && (address != null)) {
+			server.setAddress(address);
 		}
 	}
 
@@ -934,8 +934,8 @@ public class IrcConnection {
 	 *            The port number to use.
 	 */
 	public void setServerPort(final int port) {
-		if (!this.isConnected() && (port > 0)) {
-			this.server.setPort(port);
+		if (!isConnected() && (port > 0)) {
+			server.setPort(port);
 		}
 	}
 
@@ -950,8 +950,8 @@ public class IrcConnection {
 	 * @see #setServerPort(int)
 	 */
 	public void setUsingSSL(final boolean usingSSL) {
-		if (!this.isConnected()) {
-			this.server.setSecure(usingSSL);
+		if (!isConnected()) {
+			server.setSecure(usingSSL);
 		}
 	}
 

--- a/src/main/java/com/sorcix/sirc/IrcConnection.java
+++ b/src/main/java/com/sorcix/sirc/IrcConnection.java
@@ -872,7 +872,6 @@ public class IrcConnection {
 			if (username != null) {
 				if (state.getClient() == null) {
 					state.setClient(new User(null, username, null, realname, this));
-					return;
 				}
 			}
 		}

--- a/src/main/java/com/sorcix/sirc/IrcInput.java
+++ b/src/main/java/com/sorcix/sirc/IrcInput.java
@@ -119,7 +119,7 @@ final class IrcInput extends Thread {
 		} catch (final IOException ex) {
 			this.irc.setConnected(false);
 		} catch (final Exception ex) {
-                        IrcDebug.log("Exception " + ex + " on: " + line);
+			IrcDebug.log("Exception " + ex + " on: " + line);
 			ex.printStackTrace();
 		}
 		// when reaching this, we are disconnected

--- a/src/main/java/com/sorcix/sirc/IrcInput.java
+++ b/src/main/java/com/sorcix/sirc/IrcInput.java
@@ -54,9 +54,9 @@ final class IrcInput extends Thread {
 	 * @param in The stream to use for communication.
 	 */
 	protected IrcInput(final IrcConnection irc, final Reader in) {
-		this.setName("sIRC-IN:" + irc.getServerAddress() + "-" + irc.getClient().getUserName());
-		this.setPriority(Thread.NORM_PRIORITY);
-		this.setDaemon(false);
+		setName("sIRC-IN:" + irc.getServerAddress() + "-" + irc.getClient().getUserName());
+		setPriority(Thread.NORM_PRIORITY);
+		setDaemon(false);
 		this.in = new BufferedReader(in);
 		this.irc = irc;
 	}
@@ -68,7 +68,7 @@ final class IrcInput extends Thread {
 	 * @see IrcConnection#disconnect()
 	 */
 	protected void close() throws IOException {
-		this.in.close();
+		in.close();
 	}
 	
 	/**
@@ -77,7 +77,7 @@ final class IrcInput extends Thread {
 	 * @return the reader.
 	 */
 	protected BufferedReader getReader() {
-		return this.in;
+		return in;
 	}
 	
 	/**
@@ -87,14 +87,14 @@ final class IrcInput extends Thread {
 	 */
 	private void handleLine(final String line) {
 		// transform the raw line into an easier format
-		final IrcPacket parser = new IrcPacket(line, this.irc);
+		final IrcPacket parser = new IrcPacket(line, irc);
 		// Handle numeric server replies.
 		if (parser.isNumeric()) {
-			this.parser.parseNumeric(this.irc, parser);
+			this.parser.parseNumeric(irc, parser);
 			return;
 		}
 		// Handle different commands
-		this.parser.parseCommand(this.irc, parser);
+		this.parser.parseCommand(irc, parser);
 	}
 	
 	/**
@@ -105,30 +105,30 @@ final class IrcInput extends Thread {
 		String line = null;
 		try {
 			// wait for lines to come in
-			while ((line = this.in.readLine()) != null) {
+			while ((line = in.readLine()) != null) {
 				IrcDebug.log("<<< " + line);
 				// always respond to PING
 				if (line.startsWith("PING ")) {
-					this.irc.out.pong(line.substring(5));
+					irc.out.pong(line.substring(5));
 				} else {
-					this.handleLine(line);
+					handleLine(line);
 				}
 			}
 		} catch (final SocketException ex) {
-			this.irc.setConnected(false);
+			irc.setConnected(false);
 		} catch (final IOException ex) {
-			this.irc.setConnected(false);
+			irc.setConnected(false);
 		} catch (final Exception ex) {
 			IrcDebug.log("Exception " + ex + " on: " + line);
 			ex.printStackTrace();
 		}
 		// when reaching this, we are disconnected
-		this.irc.setConnected(false);
+		irc.setConnected(false);
 		// close connections
-		this.irc.disconnect();
+		irc.disconnect();
 		// send disconnect event
-		for (final Iterator<ServerListener> it = this.irc.getServerListeners(); it.hasNext();) {
-			it.next().onDisconnect(this.irc);
+		for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
+			it.next().onDisconnect(irc);
 		}
 	}
 }

--- a/src/main/java/com/sorcix/sirc/IrcOutput.java
+++ b/src/main/java/com/sorcix/sirc/IrcOutput.java
@@ -54,11 +54,11 @@ class IrcOutput extends Thread {
 	 * @param out The stream to use for communication.
 	 */
 	protected IrcOutput(final IrcConnection irc, final Writer out) {
-		this.setName("sIRC-OUT:" + irc.getServerAddress() + "-" + irc.getClient().getUserName());
-		this.setPriority(Thread.MIN_PRIORITY);
-		this.setDaemon(true);
+		setName("sIRC-OUT:" + irc.getServerAddress() + "-" + irc.getClient().getUserName());
+		setPriority(Thread.MIN_PRIORITY);
+		setDaemon(true);
 		this.irc = irc;
-		this.queue = new IrcQueue();
+		queue = new IrcQueue();
 		this.out = new BufferedWriter(out);
 	}
 	
@@ -69,8 +69,8 @@ class IrcOutput extends Thread {
 	 * @see IrcConnection#disconnect()
 	 */
 	protected void close() throws IOException {
-		this.out.flush();
-		this.out.close();
+		out.flush();
+		out.close();
 	}
 	
 	/**
@@ -82,10 +82,10 @@ class IrcOutput extends Thread {
 			boolean running = true;
 			String line;
 			while (running) {
-				Thread.sleep(this.irc.getMessageDelay());
-				line = this.queue.take();
+				Thread.sleep(irc.getMessageDelay());
+				line = queue.take();
 				if (line != null) {
-					this.sendNow(line);
+					sendNow(line);
 				} else {
 					running = false;
 				}
@@ -107,11 +107,11 @@ class IrcOutput extends Thread {
 	 * @param packet The data to send.
 	 */
 	protected synchronized void send(final IrcPacket packet) {
-		if (this.irc.getMessageDelay() == 0) {
-			this.sendNow(packet.getRaw());
+		if (irc.getMessageDelay() == 0) {
+			sendNow(packet.getRaw());
 			return;
 		}
-		this.queue.add(packet.getRaw());
+		queue.add(packet.getRaw());
 	}
 	
 	/**
@@ -123,11 +123,11 @@ class IrcOutput extends Thread {
 	@Deprecated
 	protected synchronized void send(final String line) {
 		//TODO: Remove in a future release.
-		if (this.irc.getMessageDelay() == 0) {
-			this.sendNow(line);
+		if (irc.getMessageDelay() == 0) {
+			sendNow(line);
 			return;
 		}
-		this.queue.add(line);
+		queue.add(line);
 	}
 	
 	/**
@@ -139,7 +139,7 @@ class IrcOutput extends Thread {
 	 */
 	protected synchronized void sendNow(final IrcPacket packet) {
 		try {
-			this.sendNowEx(packet.getRaw());
+			sendNowEx(packet.getRaw());
 		} catch (final Exception ex) {
 			// ignore
 		}
@@ -157,7 +157,7 @@ class IrcOutput extends Thread {
 	protected synchronized void sendNow(final String line) {
 		//TODO: Remove in a future release.
 		try {
-			this.sendNowEx(line);
+			sendNowEx(line);
 		} catch (final Exception ex) {
 			throw new IllegalStateException(ex);
 		}
@@ -172,7 +172,7 @@ class IrcOutput extends Thread {
 	 *             message.
 	 */
 	protected synchronized void sendNowEx(final IrcPacket packet) throws IOException {
-		this.sendNowEx(packet.getRaw());
+		sendNowEx(packet.getRaw());
 	}
 	
 	/**
@@ -188,8 +188,8 @@ class IrcOutput extends Thread {
 			line = line.substring(0, IrcOutput.MAX_LINE_LENGTH - 2);
 		}
 		IrcDebug.log(">>> " + line);
-		this.out.write(line + IrcConnection.ENDLINE);
-		this.out.flush();
+		out.write(line + IrcConnection.ENDLINE);
+		out.flush();
 	}
 
 	/**
@@ -198,7 +198,7 @@ class IrcOutput extends Thread {
 	 */
 	protected void pong(String code) {
 		try {
-			this.sendNowEx("PONG "+code);
+			sendNowEx("PONG "+code);
 		} catch (final Exception ex) {
 			// ignore
 		}

--- a/src/main/java/com/sorcix/sirc/IrcOutput.java
+++ b/src/main/java/com/sorcix/sirc/IrcOutput.java
@@ -184,7 +184,7 @@ class IrcOutput extends Thread {
 	 *             message.
 	 */
 	private synchronized void sendNowEx(String line) throws IOException {
-		if (line.length() > IrcOutput.MAX_LINE_LENGTH - 2) {
+		if (line.length() > (IrcOutput.MAX_LINE_LENGTH - 2)) {
 			line = line.substring(0, IrcOutput.MAX_LINE_LENGTH - 2);
 		}
 		IrcDebug.log(">>> " + line);

--- a/src/main/java/com/sorcix/sirc/IrcOutput.java
+++ b/src/main/java/com/sorcix/sirc/IrcOutput.java
@@ -85,7 +85,7 @@ class IrcOutput extends Thread {
 				Thread.sleep(irc.getMessageDelay());
 				line = queue.take();
 				if (line != null) {
-					sendNow(line);
+					sendNow(new IrcPacket(line, irc));
 				} else {
 					running = false;
 				}
@@ -108,7 +108,7 @@ class IrcOutput extends Thread {
 	 */
 	protected synchronized void send(final IrcPacket packet) {
 		if (irc.getMessageDelay() == 0) {
-			sendNow(packet.getRaw());
+			sendNow(packet);
 			return;
 		}
 		queue.add(packet.getRaw());
@@ -124,7 +124,7 @@ class IrcOutput extends Thread {
 	protected synchronized void send(final String line) {
 		//TODO: Remove in a future release.
 		if (irc.getMessageDelay() == 0) {
-			sendNow(line);
+			sendNow(new IrcPacket(line, irc));
 			return;
 		}
 		queue.add(line);
@@ -198,7 +198,7 @@ class IrcOutput extends Thread {
 	 */
 	protected void pong(String code) {
 		try {
-			sendNowEx("PONG "+code);
+			sendNowEx("PONG " + code);
 		} catch (final Exception ex) {
 			// ignore
 		}

--- a/src/main/java/com/sorcix/sirc/IrcPacket.java
+++ b/src/main/java/com/sorcix/sirc/IrcPacket.java
@@ -149,7 +149,7 @@ public final class IrcPacket {
 	 * @param message
 	 *            The message, or {@code null}.
 	 */
-	protected IrcPacket(final String prefix, final String command,
+	public IrcPacket(final String prefix, final String command,
 			final String arguments, final String message) {
 		this.prefix = prefix;
 		this.command = command;

--- a/src/main/java/com/sorcix/sirc/IrcPacket.java
+++ b/src/main/java/com/sorcix/sirc/IrcPacket.java
@@ -87,53 +87,53 @@ public final class IrcPacket {
 		// some messages don't have a prefix
 		if ((locLineStart > 1) || (locLineStart < 0)) {
 			locCommand = 0;
-			this.prefix = null;
+			prefix = null;
 		} else {
 			// space between sender and command
 			locCommand = line.indexOf(' ', locLineStart + 1);
 			// retrieve sender
-			this.prefix = line.substring(locLineStart, locCommand);
+			prefix = line.substring(locLineStart, locCommand);
 		}
 		// space between command and receiver
 		final int locArgs = line.indexOf(' ', locCommand + 1);
 		// retrieve command
-		this.command = line.substring(locCommand + 1, locArgs);
+		command = line.substring(locCommand + 1, locArgs);
 		// colon between arguments and message
 		final int locMsg = line.indexOf(':', locArgs);
 		// if there are arguments, save them
 		if ((locMsg - locArgs) > 1) {
-			this.arguments = line.substring(locArgs + 1, locMsg - 1);
+			arguments = line.substring(locArgs + 1, locMsg - 1);
 		} else if (locMsg < 0) {
 			// there is no message, so arguments go to the end
-			this.arguments = line.substring(locArgs + 1);
+			arguments = line.substring(locArgs + 1);
 		}
 		// If there is a message, save it
 		if (locMsg > 0) {
-			this.message = line.substring(locMsg + 1);
+			message = line.substring(locMsg + 1);
 			// check if this message is a CTCP request
-			if (this.message.startsWith(IrcPacket.CTCP)
-					&& this.message.endsWith(IrcPacket.CTCP)) {
-				this.ctcp = true;
-				this.message = this.message.substring(1,
-						this.message.length() - 1);
+			if (message.startsWith(IrcPacket.CTCP)
+					&& message.endsWith(IrcPacket.CTCP)) {
+				ctcp = true;
+				message = message.substring(1,
+						message.length() - 1);
 			}
 		}
 		// check if the command is a server reply
-		this.cmdNumeric = this.getInteger(this.command);
-		if (this.cmdNumeric != -1) {
+		cmdNumeric = getInteger(command);
+		if (cmdNumeric != -1) {
 			// numeric server response
-			this.numeric = true;
+			numeric = true;
 		}
 		// if possible, parse the sender into a user object
 		// TODO: Get this out of here, this shouldn't be in IrcPacket..
-		if ((this.prefix != null) && (this.prefix.indexOf('!') > 0)) {
-			final String[] stuff = this.prefix.split("@|!");
+		if ((prefix != null) && (prefix.indexOf('!') > 0)) {
+			final String[] stuff = prefix.split("@|!");
 			if (stuff.length == 3) {
-				this.sender = new User(stuff[0], stuff[1], stuff[2], null, irc);
+				sender = new User(stuff[0], stuff[1], stuff[2], null, irc);
 			} else if (stuff.length == 1)
-				this.sender = new User(stuff[0], irc);
+				sender = new User(stuff[0], irc);
 		} else if (prefix != null) {
-			this.sender = new User(this.prefix, irc);
+			sender = new User(prefix, irc);
 		}
 	}
 
@@ -163,7 +163,7 @@ public final class IrcPacket {
 	 * @return Arguments string, or {@code null} if there were none.
 	 */
 	public String getArguments() {
-		return this.arguments;
+		return arguments;
 	}
 
 	/**
@@ -172,7 +172,7 @@ public final class IrcPacket {
 	 * @return Arguments array, or {@code null} if there were none.
 	 */
 	public String[] getArgumentsArray() {
-		return this.arguments != null ? this.arguments.split(" ") : null;
+		return arguments != null ? arguments.split(" ") : null;
 	}
 
 	/**
@@ -181,7 +181,7 @@ public final class IrcPacket {
 	 * @return The command string.
 	 */
 	public String getCommand() {
-		return this.command;
+		return command;
 	}
 
 	/**
@@ -205,7 +205,7 @@ public final class IrcPacket {
 	 * @return Message string, or {@code null} if there was none.
 	 */
 	public String getMessage() {
-		return this.message;
+		return message;
 	}
 
 	/**
@@ -214,7 +214,7 @@ public final class IrcPacket {
 	 * @return The command integer.
 	 */
 	public int getNumericCommand() {
-		return this.cmdNumeric;
+		return cmdNumeric;
 	}
 
 	/**
@@ -224,7 +224,7 @@ public final class IrcPacket {
 	 * @return The sender string.
 	 */
 	public String getPrefix() {
-		return this.prefix;
+		return prefix;
 	}
 
 	/**
@@ -235,15 +235,15 @@ public final class IrcPacket {
 	protected String getRaw() {
 		final StringBuffer buffer = new StringBuffer();
 
-		if ((this.prefix != null) && (this.prefix.length() > 0)) {
-			buffer.append(":").append(this.prefix).append(" ");
+		if ((prefix != null) && (prefix.length() > 0)) {
+			buffer.append(":").append(prefix).append(" ");
 		}
-		buffer.append(this.command);
-		if ((this.arguments != null) && (this.arguments.length() > 0)) {
-			buffer.append(" ").append(this.arguments);
+		buffer.append(command);
+		if ((arguments != null) && (arguments.length() > 0)) {
+			buffer.append(" ").append(arguments);
 		}
-		if ((this.message != null) && (this.message.length() > 0)) {
-			buffer.append(" :").append(this.message);
+		if ((message != null) && (message.length() > 0)) {
+			buffer.append(" :").append(message);
 		}
 		return buffer.toString();
 	}
@@ -255,7 +255,7 @@ public final class IrcPacket {
 	 *         user.
 	 */
 	public User getSender() {
-		return this.sender;
+		return sender;
 	}
 
 	/**

--- a/src/main/java/com/sorcix/sirc/IrcPacket.java
+++ b/src/main/java/com/sorcix/sirc/IrcPacket.java
@@ -264,7 +264,7 @@ public final class IrcPacket {
 	 * @return True if there were arguments.
 	 */
 	public boolean hasArguments() {
-		return (this.arguments != null) && (this.arguments.length() > 0);
+		return (arguments != null) && (arguments.length() > 0);
 	}
 
 	/**
@@ -273,7 +273,7 @@ public final class IrcPacket {
 	 * @return True if there was a message.
 	 */
 	public boolean hasMessage() {
-		return (this.message != null) && (this.message.trim().length() > 0);
+		return (message != null) && (message.trim().length() > 0);
 	}
 
 	/**
@@ -282,7 +282,7 @@ public final class IrcPacket {
 	 * @return True if this message was sent using CTCP, false otherwise.
 	 */
 	public boolean isCtcp() {
-		return this.ctcp;
+		return ctcp;
 	}
 
 	/**
@@ -291,6 +291,6 @@ public final class IrcPacket {
 	 * @return True if this line is a numeric reply.
 	 */
 	public boolean isNumeric() {
-		return this.numeric;
+		return numeric;
 	}
 }

--- a/src/main/java/com/sorcix/sirc/IrcParser.java
+++ b/src/main/java/com/sorcix/sirc/IrcParser.java
@@ -185,7 +185,7 @@ final class IrcParser {
 				it.next().onKick(irc, channel, line.getSender(), kicked, line.getMessage());
 			}
 		} else if (line.getCommand().equals("MODE")) {
-			this.parseMode(irc, line);
+			parseMode(irc, line);
 		} else if (line.getCommand().equals("TOPIC")) {
 			// someone changed the topic.
 			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
@@ -346,16 +346,16 @@ final class IrcParser {
 				}
 				break;
 			case IrcPacket.RPL_MOTD:
-				if (this.buffer == null) {
-					this.buffer = new StringBuffer();
+				if (buffer == null) {
+					buffer = new StringBuffer();
 				}
-				this.buffer.append(line.getMessage());
-				this.buffer.append(IrcConnection.ENDLINE);
+				buffer.append(line.getMessage());
+				buffer.append(IrcConnection.ENDLINE);
 				break;
 			case IrcPacket.RPL_ENDOFMOTD:
-				if (this.buffer != null) {
-					final String motd = this.buffer.toString();
-					this.buffer = null;
+				if (buffer != null) {
+					final String motd = buffer.toString();
+					buffer = null;
 					for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
 						it.next().onMotd(irc, motd);
 					}

--- a/src/main/java/com/sorcix/sirc/IrcParser.java
+++ b/src/main/java/com/sorcix/sirc/IrcParser.java
@@ -85,20 +85,17 @@ final class IrcParser {
 					// send error message
 					line.getSender().sendCtcpReply("ERRMSG CTCP Command not supported. Use CLIENTINFO to list supported commands.");
 				}
-				return;
 			} else if (line.getArguments().startsWith("#") || line.getArguments().startsWith("&")) {
 				// to channel
 				final Channel chan = irc.getState().getChannel(line.getArguments());
 				for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
 					it.next().onMessage(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage());
 				}
-				return;
 			} else {
 				// to user
 				for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
 					it.next().onPrivateMessage(irc, line.getSender(), line.getMessage());
 				}
-				return;
 			}
 		} else if (line.getCommand().equals("NOTICE") && (line.getArguments() != null)) {
 			if (line.isCtcp()) {
@@ -124,7 +121,6 @@ final class IrcParser {
 					it.next().onNotice(irc, line.getSender(), line.getMessage());
 				}
 			}
-			return;
 		} else if (line.getCommand().equals("JOIN")) {
 			// some server seem to send the joined channel as message,
 			// while others have it as an argument. (quakenet related)
@@ -146,7 +142,6 @@ final class IrcParser {
 			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
 				it.next().onJoin(irc, irc.getState().getChannel(channel), line.getSender());
 			}
-			return;
 		} else if (line.getCommand().equals("PART")) {
 			// someone left a channel
 			if (line.getSender().isUs()) {
@@ -162,7 +157,6 @@ final class IrcParser {
 			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
 				it.next().onPart(irc, irc.getState().getChannel(line.getArguments()), line.getSender(), line.getMessage());
 			}
-			return;
 		} else if (line.getCommand().equals("QUIT")) {
 			// someone quit the IRC server
 			final User quitter = line.getSender();
@@ -175,7 +169,6 @@ final class IrcParser {
 					channel.removeUser(quitter);
 				}
 			}
-			return;
 		} else if (line.getCommand().equals("KICK")) {
 			// someone was kicked from a channel
 			final String[] data = line.getArgumentsArray();
@@ -192,17 +185,14 @@ final class IrcParser {
 			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
 				it.next().onKick(irc, channel, line.getSender(), kicked, line.getMessage());
 			}
-			return;
 		} else if (line.getCommand().equals("MODE")) {
 			this.parseMode(irc, line);
-			return;
 		} else if (line.getCommand().equals("TOPIC")) {
 			// someone changed the topic.
 			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
 				final Channel chan = irc.getState().getChannel(line.getArguments());
 				it.next().onTopic(irc, chan, chan.updateUser(line.getSender(), false), line.getMessage());
 			}
-			return;
 		} else if (line.getCommand().equals("NICK")) {
 			User newUser;
 			if (line.hasMessage()) {
@@ -221,7 +211,6 @@ final class IrcParser {
 			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
 				it.next().onNick(irc, line.getSender(), newUser);
 			}
-			return;
 		} else if (line.getCommand().equals("INVITE")) {
 			// someone was invited
 			final String[] args = line.getArgumentsArray();
@@ -231,7 +220,6 @@ final class IrcParser {
 					it.next().onInvite(irc, line.getSender(), new User(args[0], irc), channel);
 				}
 			}
-			return;
 		} else {
 			if (irc.getAdvancedListener() != null) {
 				irc.getAdvancedListener().onUnknown(irc, line);

--- a/src/main/java/com/sorcix/sirc/IrcParser.java
+++ b/src/main/java/com/sorcix/sirc/IrcParser.java
@@ -243,7 +243,7 @@ final class IrcParser {
 			if ((args.length >= 3)) {
 				final Channel channel = irc.getState().getChannel(args[0]);
 				final String mode = args[1];
-				final boolean enable = mode.charAt(0) == '+' ? true : false;
+				final boolean enable = mode.charAt(0) == '+';
 				char current;
 				// tries all known modes.
 				// this is an ugly part of sIRC, but the only way to

--- a/src/main/java/com/sorcix/sirc/IrcParser.java
+++ b/src/main/java/com/sorcix/sirc/IrcParser.java
@@ -108,7 +108,6 @@ final class IrcParser {
 						it.next().onCtcpReply(irc, line.getSender(), command, args);
 					}
 				}
-				return;
 			} else if (Channel.CHANNEL_PREFIX.indexOf(line.getArguments().charAt(0)) >= 0) {
 				// to channel
 				final Channel chan = irc.getState().getChannel(line.getArguments());

--- a/src/main/java/com/sorcix/sirc/IrcQueue.java
+++ b/src/main/java/com/sorcix/sirc/IrcQueue.java
@@ -43,7 +43,7 @@ final class IrcQueue {
 	 * Creates a new outgoing message queue.
 	 */
 	protected IrcQueue() {
-		this.queue = new LinkedList<String>();
+		queue = new LinkedList<String>();
 	}
 	
 	/**
@@ -52,9 +52,9 @@ final class IrcQueue {
 	 * @param line The raw IRC line to add to the queue.
 	 */
 	protected void add(final String line) {
-		synchronized (this.queue) {
-			this.queue.addLast(line);
-			this.queue.notify();
+		synchronized (queue) {
+			queue.addLast(line);
+			queue.notify();
 		}
 	}
 	
@@ -66,9 +66,9 @@ final class IrcQueue {
 	 * @param line The raw IRC line to add to the queue.
 	 */
 	protected void addToFront(final String line) {
-		synchronized (this.queue) {
-			this.queue.addFirst(line);
-			this.queue.notify();
+		synchronized (queue) {
+			queue.addFirst(line);
+			queue.notify();
 		}
 	}
 	
@@ -79,16 +79,16 @@ final class IrcQueue {
 	 */
 	protected String take() {
 		String line;
-		synchronized (this.queue) {
-			if (this.queue.isEmpty()) {
+		synchronized (queue) {
+			if (queue.isEmpty()) {
 				try {
-					this.queue.wait();
+					queue.wait();
 				} catch (final InterruptedException e) {
 					return null;
 				}
 			}
-			line = this.queue.getFirst();
-			this.queue.removeFirst();
+			line = queue.getFirst();
+			queue.removeFirst();
 			return line;
 		}
 	}

--- a/src/main/java/com/sorcix/sirc/IrcServer.java
+++ b/src/main/java/com/sorcix/sirc/IrcServer.java
@@ -86,7 +86,7 @@ public class IrcServer {
 	 * @return The server address.
 	 */
 	public String getAddress() {
-		return this.address;
+		return address;
 	}
 	
 	/**
@@ -95,7 +95,7 @@ public class IrcServer {
 	 * @return The server password, or {@code null}.
 	 */
 	public String getPassword() {
-		return this.password;
+		return password;
 	}
 	
 	/**
@@ -104,7 +104,7 @@ public class IrcServer {
 	 * @return The server port.
 	 */
 	public int getPort() {
-		return this.port;
+		return port;
 	}
 	
 	/**
@@ -113,7 +113,7 @@ public class IrcServer {
 	 * @return True if this server is using SSL, false otherwise.
 	 */
 	public boolean isSecure() {
-		return this.secure;
+		return secure;
 	}
 	
 	/**

--- a/src/main/java/com/sorcix/sirc/User.java
+++ b/src/main/java/com/sorcix/sirc/User.java
@@ -95,18 +95,18 @@ public final class User {
 	 *            user.
 	 */
 	protected User(final String nick, final String user, final String host, final String realName, final IrcConnection irc) {
-		this.setNick(nick);
+		setNick(nick);
 		this.realName = realName;
-		this.userName = user;
-		this.hostName = host;
 		this.irc = irc;
-		this.address = this.getNick();
+		userName = user;
+		hostName = host;
+		address = getNick();
 	}
 	
 	@Override
 	public boolean equals(final Object user) {
 		try {
-			return ((User) user).getNick().equalsIgnoreCase(this.nick);
+			return ((User) user).getNick().equalsIgnoreCase(nick);
 		} catch (final Exception ex) {
 			return false;
 		}
@@ -117,7 +117,7 @@ public final class User {
 	 * @return The address used to send messages to this user.
 	 */
 	private String getAddress() {
-		return this.address;
+		return address;
 	}
 	
 	/**
@@ -126,7 +126,7 @@ public final class User {
 	 * @return The hostname, or null if unknown.
 	 */
 	public String getHostName() {
-		return this.hostName;
+		return hostName;
 	}
 	
 	/**
@@ -135,7 +135,7 @@ public final class User {
 	 * @return The nickname.
 	 */
 	public String getNick() {
-		return this.nick;
+		return nick;
 	}
 	
 	/**
@@ -144,7 +144,7 @@ public final class User {
 	 * @return Lowercase nickname.
 	 */
 	public String getNickLower() {
-		return this.nickLower;
+		return nickLower;
 	}
 	
 	/**
@@ -153,7 +153,7 @@ public final class User {
 	 * @return The prefix.
 	 */
 	public char getPrefix() {
-		return this.prefix;
+		return prefix;
 	}
 	
 	/**
@@ -162,11 +162,11 @@ public final class User {
 	 * @return The username.
 	 */
 	public String getUserName() {
-		return this.userName;
+		return userName;
 	}
 
 	public String getRealName() {
-		return this.realName != null ? this.realName : this.nick;
+		return realName != null ? realName : nick;
 	}
 
 	/**
@@ -176,7 +176,7 @@ public final class User {
 	 * @since 1.1.0
 	 */
 	public boolean hasAdmin() {
-		return this.getPrefix() == User.PREFIX_ADMIN;
+		return getPrefix() == User.PREFIX_ADMIN;
 	}
 	
 	/**
@@ -186,7 +186,7 @@ public final class User {
 	 * @since 1.1.0
 	 */
 	public boolean hasFounder() {
-		return this.getPrefix() == User.PREFIX_FOUNDER;
+		return getPrefix() == User.PREFIX_FOUNDER;
 	}
 	
 	/**
@@ -196,7 +196,7 @@ public final class User {
 	 * @since 1.1.0
 	 */
 	public boolean hasHalfOp() {
-		return this.getPrefix() == User.PREFIX_HALF_OP;
+		return getPrefix() == User.PREFIX_HALF_OP;
 	}
 	
 	/**
@@ -206,7 +206,7 @@ public final class User {
 	 * @since 1.1.0
 	 */
 	public boolean hasOperator() {
-		return this.getPrefix() == User.PREFIX_OPERATOR;
+		return getPrefix() == User.PREFIX_OPERATOR;
 	}
 	
 	/**
@@ -216,7 +216,7 @@ public final class User {
 	 * @since 1.1.0
 	 */
 	public boolean hasVoice() {
-		return this.getPrefix() == User.PREFIX_VOICE;
+		return getPrefix() == User.PREFIX_VOICE;
 	}
 	
 	/**
@@ -227,7 +227,7 @@ public final class User {
 	 * @see IrcConnection#isUs(User)
 	 */
 	public boolean isUs() {
-		return this.irc.isUs(this);
+		return irc.isUs(this);
 	}
 	
 	/**
@@ -237,7 +237,7 @@ public final class User {
 	 * @see #sendMessage(String)
 	 */
 	public void send(final String message) {
-		this.sendMessage(message);
+		sendMessage(message);
 	}
 	
 	/**
@@ -246,7 +246,7 @@ public final class User {
 	 * @param action The action to send.
 	 */
 	public void sendAction(final String action) {
-		this.sendCtcpAction(action);
+		sendCtcpAction(action);
 	}
 	
 	/**
@@ -256,7 +256,7 @@ public final class User {
 	 * @param command Command to send.
 	 */
 	public void sendCtcp(final String command) {
-		this.irc.getOutput().send("PRIVMSG " + this.getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+		irc.getOutput().send("PRIVMSG " + getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
 	}
 	
 	/**
@@ -267,7 +267,7 @@ public final class User {
 	 */
 	protected void sendCtcpAction(final String action) {
 		if ((action != null) && (action.length() != 0)) {
-			this.sendCtcp("ACTION " + action);
+			sendCtcp("ACTION " + action);
 		}
 	}
 	
@@ -275,7 +275,7 @@ public final class User {
 	 * Sends a CTCP CLIENTINFO command.
 	 */
 	public void sendCtcpClientInfo() {
-		this.sendCtcp("CLIENTINFO");
+		sendCtcp("CLIENTINFO");
 	}
 	
 	/**
@@ -285,7 +285,7 @@ public final class User {
 	 */
 	public long sendCtcpPing() {
 		final Long time = System.currentTimeMillis();
-		this.sendCtcp("PING " + time.toString());
+		sendCtcp("PING " + time.toString());
 		return time;
 	}
 	
@@ -296,7 +296,7 @@ public final class User {
 	 * @param command Command to send.
 	 */
 	protected void sendCtcpReply(final String command) {
-		this.sendCtcpReply(command, false);
+		sendCtcpReply(command, false);
 	}
 	
 	/**
@@ -308,9 +308,9 @@ public final class User {
 	 */
 	protected void sendCtcpReply(final String command, final boolean skipQueue) {
 		if (skipQueue) {
-			this.irc.getOutput().sendNow("NOTICE " + this.getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+			irc.getOutput().sendNow("NOTICE " + getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
 		} else {
-			this.irc.getOutput().send("NOTICE " + this.getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+			irc.getOutput().send("NOTICE " + getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
 		}
 	}
 	
@@ -318,7 +318,7 @@ public final class User {
 	 * Sends a CTCP VERSION command to this user.
 	 */
 	public void sendCtcpVersion() {
-		this.sendCtcp("VERSION");
+		sendCtcp("VERSION");
 	}
 	
 	/**
@@ -327,7 +327,7 @@ public final class User {
 	 * @param message The message to send.
 	 */
 	public void sendMessage(final String message) {
-		this.irc.getOutput().send("PRIVMSG " + this.getAddress() + " :" + message);
+		irc.getOutput().send("PRIVMSG " + getAddress() + " :" + message);
 	}
 	
 	/**
@@ -336,7 +336,7 @@ public final class User {
 	 * @param message The notice to send.
 	 */
 	public void sendNotice(final String message) {
-		this.irc.getOutput().send("NOTICE " + this.getAddress() + " :" + message);
+		irc.getOutput().send("NOTICE " + getAddress() + " :" + message);
 	}
 	
 	/**
@@ -349,9 +349,9 @@ public final class User {
 	 */
 	public void setCustomAddress(final String address) {
 		if (address == null) {
-			this.address = this.getNick();
+			this.address = getNick();
 		} else if (address.startsWith("@")) {
-			this.address = this.getNick() + address;
+			this.address = getNick() + address;
 		} else {
 			this.address = address;
 		}
@@ -365,9 +365,9 @@ public final class User {
 	 */
 	public void setMode(final char mode, final boolean toggle) {
 		if (toggle) {
-			this.setMode("+" + mode);
+			setMode("+" + mode);
 		} else {
-			this.setMode("-" + mode);
+			setMode("-" + mode);
 		}
 	}
 	
@@ -381,7 +381,7 @@ public final class User {
 	 * @param mode The mode to change.
 	 */
 	public void setMode(final String mode) {
-		this.irc.getOutput().send("MODE " + this.getAddress() + " " + mode);
+		irc.getOutput().send("MODE " + getAddress() + " " + mode);
 	}
 	
 	/**
@@ -393,23 +393,23 @@ public final class User {
 		if (nick == null)
 			return;
 		if (User.USER_PREFIX.indexOf(nick.charAt(0)) >= 0) {
-			this.prefix = nick.charAt(0);
+			prefix = nick.charAt(0);
 			nick = nick.substring(1);
 		}
 		this.nick = nick;
-		this.nickLower = nick.toLowerCase();
+		nickLower = nick.toLowerCase();
 		// TODO: Check whether addresses like nick!user@server are
 		// allowed
-		if ((this.address != null) && this.address.contains("@")) {
-			this.address = this.nick + "@" + this.address.split("@", 2)[1];
+		if ((address != null) && address.contains("@")) {
+			address = this.nick + "@" + address.split("@", 2)[1];
 		} else {
-			this.address = this.nick;
+			address = this.nick;
 		}
 	}
 	
 	@Override
 	public String toString() {
-		return this.getNick();
+		return getNick();
 	}
 	
 	/**

--- a/src/main/java/com/sorcix/sirc/User.java
+++ b/src/main/java/com/sorcix/sirc/User.java
@@ -256,7 +256,7 @@ public final class User {
 	 * @param command Command to send.
 	 */
 	public void sendCtcp(final String command) {
-		irc.getOutput().send("PRIVMSG " + getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+		irc.getOutput().send(new IrcPacket(null, "PRIVMSG", getAddress(), IrcPacket.CTCP + command + IrcPacket.CTCP));
 	}
 	
 	/**
@@ -308,9 +308,9 @@ public final class User {
 	 */
 	protected void sendCtcpReply(final String command, final boolean skipQueue) {
 		if (skipQueue) {
-			irc.getOutput().sendNow("NOTICE " + getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+			irc.getOutput().sendNow(new IrcPacket(null, "NOTICE", getAddress(), IrcPacket.CTCP + command + IrcPacket.CTCP));
 		} else {
-			irc.getOutput().send("NOTICE " + getAddress() + " :" + IrcPacket.CTCP + command + IrcPacket.CTCP);
+			irc.getOutput().send(new IrcPacket(null, "NOTICE", getAddress(), IrcPacket.CTCP + command + IrcPacket.CTCP));
 		}
 	}
 	
@@ -327,7 +327,7 @@ public final class User {
 	 * @param message The message to send.
 	 */
 	public void sendMessage(final String message) {
-		irc.getOutput().send("PRIVMSG " + getAddress() + " :" + message);
+		irc.getOutput().send(new IrcPacket(null, "PRIVMSG", getAddress(), message));
 	}
 	
 	/**
@@ -336,7 +336,7 @@ public final class User {
 	 * @param message The notice to send.
 	 */
 	public void sendNotice(final String message) {
-		irc.getOutput().send("NOTICE " + getAddress() + " :" + message);
+		irc.getOutput().send(new IrcPacket(null, "NOTICE", getAddress(), message));
 	}
 	
 	/**
@@ -381,7 +381,7 @@ public final class User {
 	 * @param mode The mode to change.
 	 */
 	public void setMode(final String mode) {
-		irc.getOutput().send("MODE " + getAddress() + " " + mode);
+		irc.getOutput().send(new IrcPacket(null, "MODE", getAddress() + mode, null));
 	}
 	
 	/**

--- a/src/test/java/com/sorcix/sirc/UserTest.java
+++ b/src/test/java/com/sorcix/sirc/UserTest.java
@@ -1,13 +1,12 @@
 package com.sorcix.sirc;
 
-import static org.mockito.Matchers.matches;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserTest {
@@ -24,7 +23,7 @@ public class UserTest {
         final User user = new User("a", connection);
         user.sendAction("hello");
 
-        verify(ircOutput).send("PRIVMSG a :" + IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP);
+        verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
     }
 
     @Test
@@ -34,7 +33,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendAction(" hello ");
 
-        verify(ircOutput).send("PRIVMSG b :" + IrcPacket.CTCP + "ACTION  hello " + IrcPacket.CTCP);
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
     }
 
     @Test
@@ -44,7 +43,7 @@ public class UserTest {
         final User user = new User("c", connection);
         user.sendAction(":");
 
-        verify(ircOutput).send("PRIVMSG c :" + IrcPacket.CTCP + "ACTION :" + IrcPacket.CTCP);
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "c", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
     }
 
     @Test
@@ -54,7 +53,7 @@ public class UserTest {
         final User user = new User("a", connection);
         user.sendCtcpPing();
 
-        verify(ircOutput).send(matches("PRIVMSG a :" + IrcPacket.CTCP + "PING \\d+" + IrcPacket.CTCP));
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", IrcPacket.CTCP + "PING \\d+" + IrcPacket.CTCP));
     }
 
     @Test
@@ -64,7 +63,7 @@ public class UserTest {
         final User user = new User("a", connection);
         user.sendCtcpVersion();
 
-        verify(ircOutput).send("PRIVMSG a :" + IrcPacket.CTCP + "VERSION" + IrcPacket.CTCP);
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", IrcPacket.CTCP + "VERSION" + IrcPacket.CTCP));
     }
 
     @Test
@@ -74,7 +73,7 @@ public class UserTest {
         final User user = new User("a", connection);
         user.sendMessage("hello");
 
-        verify(ircOutput).send("PRIVMSG a :hello");
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", "hello"));
     }
 
     @Test
@@ -84,7 +83,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendMessage(" hello ");
 
-        verify(ircOutput).send("PRIVMSG b : hello ");
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", "hello"));
     }
 
     @Test
@@ -94,7 +93,7 @@ public class UserTest {
         final User user = new User("c", connection);
         user.sendMessage(":");
 
-        verify(ircOutput).send("PRIVMSG c ::");
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", ":"));
     }
 
     @Test
@@ -104,7 +103,7 @@ public class UserTest {
         final User user = new User("a", connection);
         user.sendNotice("hello");
 
-        verify(ircOutput).send("NOTICE a :hello");
+	    verify(ircOutput).send(new IrcPacket(null, "NOTICE", "a", "hello"));
     }
 
     @Test
@@ -114,7 +113,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendNotice(" hello ");
 
-        verify(ircOutput).send("NOTICE b : hello ");
+	    verify(ircOutput).send(new IrcPacket(null, "NOTICE", "b", "hello"));
     }
 
     @Test
@@ -124,6 +123,6 @@ public class UserTest {
         final User user = new User("c", connection);
         user.sendNotice(":");
 
-        verify(ircOutput).send("NOTICE c ::");
+	    verify(ircOutput).send(new IrcPacket(null, "NOTICE", "c", ":"));
     }
 }

--- a/src/test/java/com/sorcix/sirc/UserTest.java
+++ b/src/test/java/com/sorcix/sirc/UserTest.java
@@ -33,7 +33,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendAction(" hello ");
 
-	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", IrcPacket.CTCP + "ACTION hello " + IrcPacket.CTCP));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class UserTest {
         final User user = new User("c", connection);
         user.sendAction(":");
 
-	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "c", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "c", IrcPacket.CTCP + "ACTION :" + IrcPacket.CTCP));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class UserTest {
         final User user = new User("a", connection);
         user.sendCtcpPing();
 
-	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", IrcPacket.CTCP + "PING \\d+" + IrcPacket.CTCP));
+	    verify(ircOutput).send(new IrcPacket(matches("PRIVMSG a :" + IrcPacket.CTCP + "PING \\d+" + IrcPacket.CTCP), connection));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendMessage(" hello ");
 
-	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", "hello"));
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", " hello "));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendNotice(" hello ");
 
-	    verify(ircOutput).send(new IrcPacket(null, "NOTICE", "b", "hello"));
+	    verify(ircOutput).send(new IrcPacket(null, "NOTICE", "b", " hello "));
     }
 
     @Test

--- a/src/test/java/com/sorcix/sirc/UserTest.java
+++ b/src/test/java/com/sorcix/sirc/UserTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/sorcix/sirc/UserTest.java
+++ b/src/test/java/com/sorcix/sirc/UserTest.java
@@ -33,7 +33,7 @@ public class UserTest {
         final User user = new User("b", connection);
         user.sendAction(" hello ");
 
-	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "a", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", IrcPacket.CTCP + "ACTION hello" + IrcPacket.CTCP));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class UserTest {
         final User user = new User("c", connection);
         user.sendMessage(":");
 
-	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "b", ":"));
+	    verify(ircOutput).send(new IrcPacket(null, "PRIVMSG", "c", ":"));
     }
 
     @Test


### PR DESCRIPTION
This Pull Request removes (hopefully all, unless I missed any) uses of deprecated methods in the library.
##### Some key things to note:
- To make it possible for the library users to send raw data without using deprecated methods, the IrcPacket(String, IrcConnection) constructor has been made `public`.
- Deprecated methods should now be fit for removal when you see fit as there are no longer any internal calls to them.
- This branch should be merged into `master` once approved, and the `io` branch closed.
