### PR TITLE
Fix for Java 8. Closes #11

### DIFF
--- a/src/main/java/com/sorcix/sirc/IrcColors.java
+++ b/src/main/java/com/sorcix/sirc/IrcColors.java
@@ -46,7 +46,7 @@ package com.sorcix.sirc;
  * </pre>
  * <p>
  * The mIRC website provides documentation on the color code syntax.
- * {@link "http://www.mirc.com/help/color.txt"}
+ * @see <a href="http://www.mirc.com/help/color.txt">mIRC Colours</a>
  * </p>
  * 
  * @author Sorcix


### PR DESCRIPTION
I was looking at open issues I had on my GitHub and saw this simple fix that needed doing, so I couldn't resist. My local fork now compiles perfectly with Java 8 (oraclejdk8) on Travis CI.
