### PR TITLE
Some small performance and thread safety improvements

### DIFF
--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -73,8 +73,8 @@ public final class Channel {
 	 * @param user The user to add.
 	 */
 	protected void addUser(final User user) {
-		if ((this.users != null) && !this.users.containsKey(user.getNickLower())) {
-			this.users.put(user.getNickLower(), user);
+		if (this.users != null) {
+			this.users.putIfAbsent(user.getNickLower(), user);
 		}
 	}
 	
@@ -359,7 +359,7 @@ public final class Channel {
 	 * @param user The user to remove.
 	 */
 	protected void removeUser(final User user) {
-		if ((this.users != null) && this.users.containsKey(user.getNickLower())) {
+		if (this.users != null) {
 			this.users.remove(user.getNickLower());
 		}
 	}
@@ -380,9 +380,8 @@ public final class Channel {
 	 * @param neww The new nickname.
 	 */
 	protected void renameUser(final String old, final String neww) {
-		if ((this.users != null) && this.users.containsKey(old)) {
-			final User user = this.users.get(old);
-			this.users.remove(old);
+		if (this.users != null) {
+			final User user = this.users.remove(old);
 			user.setNick(neww);
 			this.users.put(user.getNickLower(), user);
 		}

--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -383,8 +383,8 @@ public final class Channel {
 		if (this.users != null) {
 			final User user = this.users.remove(old);
 			if (user != null) {
-			  user.setNick(neww);
-			  this.users.put(user.getNickLower(), user);
+			    user.setNick(neww);
+			    this.users.put(user.getNickLower(), user);
 			}
 		}
 	}

--- a/src/main/java/com/sorcix/sirc/Channel.java
+++ b/src/main/java/com/sorcix/sirc/Channel.java
@@ -382,8 +382,10 @@ public final class Channel {
 	protected void renameUser(final String old, final String neww) {
 		if (this.users != null) {
 			final User user = this.users.remove(old);
-			user.setNick(neww);
-			this.users.put(user.getNickLower(), user);
+			if (user != null) {
+			  user.setNick(neww);
+			  this.users.put(user.getNickLower(), user);
+			}
 		}
 	}
 	

--- a/src/main/java/com/sorcix/sirc/IrcQueue.java
+++ b/src/main/java/com/sorcix/sirc/IrcQueue.java
@@ -27,7 +27,7 @@
  */
 package com.sorcix.sirc;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 
 /**
  * Outgoing message queue.
@@ -37,13 +37,13 @@ import java.util.LinkedList;
 final class IrcQueue {
 	
 	/** Message Queue. */
-	private final LinkedList<String> queue;
+	private final ArrayDeque<String> queue;
 	
 	/**
 	 * Creates a new outgoing message queue.
 	 */
 	protected IrcQueue() {
-		this.queue = new LinkedList<String>();
+		this.queue = new ArrayDeque<String>(8);
 	}
 	
 	/**


### PR DESCRIPTION
I saw some small improvements I would recommend.  There are others I want to recommend, but these seem like some more obvious inital ones.

In Channel.java I saw you were using a ConcurrentHashMap, but the way you were using it was not thread safe.  So I am providing a few recommendations to solve the thread safety in there (I will comment these per line to indicate why the change).

In IrcQueue.java it would be more performant to use an ArrayDeque than a LinkedList here.  The only reason you may not want to use it would be if you want to maintain java 1.5 compatability (as it was added in 1.6 I believe).
