### PR TITLE
Changed how listeners are called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *~
 .project
 .classpath
+.settings
+/bin

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.threadly</groupId>
+            <artifactId>threadly</threadly>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.1</version>

--- a/src/main/java/com/sorcix/sirc/IrcInput.java
+++ b/src/main/java/com/sorcix/sirc/IrcInput.java
@@ -31,7 +31,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.SocketException;
-import java.util.Iterator;
 
 /**
  * Input Thread.
@@ -127,8 +126,6 @@ final class IrcInput extends Thread {
 		// close connections
 		this.irc.disconnect();
 		// send disconnect event
-		for (final Iterator<ServerListener> it = this.irc.getServerListeners(); it.hasNext();) {
-			it.next().onDisconnect(this.irc);
-		}
+		this.irc.invokeServerListeners().onDisconnect(this.irc);
 	}
 }

--- a/src/main/java/com/sorcix/sirc/IrcParser.java
+++ b/src/main/java/com/sorcix/sirc/IrcParser.java
@@ -54,14 +54,12 @@ final class IrcParser {
 					if (Channel.CHANNEL_PREFIX.indexOf(line.getArguments().charAt(0)) >= 0) {
 						// to channel
 						final Channel chan = irc.getState().getChannel(line.getArguments());
-						for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-							it.next().onAction(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage().substring(7));
-						}
+						irc.invokeMessageListeners()
+							.onAction(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage().substring(7));
 					} else {
 						// to user
-						for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-							it.next().onAction(irc, line.getSender(), line.getMessage().substring(7));
-						}
+						irc.invokeMessageListeners()
+							.onAction(irc, line.getSender(), line.getMessage().substring(7));
 					}
 				} else if (line.getMessage().equals("VERSION") || line.getMessage().equals("FINGER")) {
 					// send custom version string
@@ -88,14 +86,11 @@ final class IrcParser {
 			} else if (line.getArguments().startsWith("#") || line.getArguments().startsWith("&")) {
 				// to channel
 				final Channel chan = irc.getState().getChannel(line.getArguments());
-				for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-					it.next().onMessage(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage());
-				}
+				irc.invokeMessageListeners()
+					.onMessage(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage());
 			} else {
 				// to user
-				for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-					it.next().onPrivateMessage(irc, line.getSender(), line.getMessage());
-				}
+				irc.invokeMessageListeners().onPrivateMessage(irc, line.getSender(), line.getMessage());
 			}
 		} else if (line.getCommand().equals("NOTICE") && (line.getArguments() != null)) {
 			if (line.isCtcp()) {
@@ -104,21 +99,16 @@ final class IrcParser {
 				final String command = line.getMessage().substring(0, cmdPos);
 				final String args = line.getMessage().substring(cmdPos + 1);
 				if (command.equals("VERSION") || command.equals("PING") || command.equals("CLIENTINFO")) {
-					for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-						it.next().onCtcpReply(irc, line.getSender(), command, args);
-					}
+					irc.invokeMessageListeners().onCtcpReply(irc, line.getSender(), command, args);
 				}
 			} else if (Channel.CHANNEL_PREFIX.indexOf(line.getArguments().charAt(0)) >= 0) {
 				// to channel
 				final Channel chan = irc.getState().getChannel(line.getArguments());
-				for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-					it.next().onNotice(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage());
-				}
+				irc.invokeMessageListeners()
+					.onNotice(irc, chan.updateUser(line.getSender(), true), chan, line.getMessage());
 			} else {
 				// to user
-				for (final Iterator<MessageListener> it = irc.getMessageListeners(); it.hasNext();) {
-					it.next().onNotice(irc, line.getSender(), line.getMessage());
-				}
+				irc.invokeMessageListeners().onNotice(irc, line.getSender(), line.getMessage());
 			}
 		} else if (line.getCommand().equals("JOIN")) {
 			// some server seem to send the joined channel as message,
@@ -138,9 +128,8 @@ final class IrcParser {
 				// add user to channel list.
 				irc.getState().getChannel(channel).addUser(line.getSender());
 			}
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				it.next().onJoin(irc, irc.getState().getChannel(channel), line.getSender());
-			}
+			irc.invokeServerListeners()
+				.onJoin(irc, irc.getState().getChannel(channel), line.getSender());
 		} else if (line.getCommand().equals("PART")) {
 			// someone left a channel
 			if (line.getSender().isUs()) {
@@ -153,15 +142,12 @@ final class IrcParser {
 				// remove user from channel list.
 				irc.getState().getChannel(line.getArguments()).removeUser(line.getSender());
 			}
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				it.next().onPart(irc, irc.getState().getChannel(line.getArguments()), line.getSender(), line.getMessage());
-			}
+			irc.invokeServerListeners()
+				.onPart(irc, irc.getState().getChannel(line.getArguments()), line.getSender(), line.getMessage());
 		} else if (line.getCommand().equals("QUIT")) {
 			// someone quit the IRC server
 			final User quitter = line.getSender();
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				it.next().onQuit(irc, quitter, line.getMessage());
-			}
+			irc.invokeServerListeners().onQuit(irc, quitter, line.getMessage());
 			for (final Iterator<Channel> it = irc.getState().getChannels(); it.hasNext();) {
 				final Channel channel = it.next();
 				if (channel.hasUser(quitter)) {
@@ -181,17 +167,15 @@ final class IrcParser {
 				// remove user from channel list.
 				channel.removeUser(kicked);
 			}
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				it.next().onKick(irc, channel, line.getSender(), kicked, line.getMessage());
-			}
+			irc.invokeServerListeners()
+				.onKick(irc, channel, line.getSender(), kicked, line.getMessage());
 		} else if (line.getCommand().equals("MODE")) {
 			this.parseMode(irc, line);
 		} else if (line.getCommand().equals("TOPIC")) {
 			// someone changed the topic.
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				final Channel chan = irc.getState().getChannel(line.getArguments());
-				it.next().onTopic(irc, chan, chan.updateUser(line.getSender(), false), line.getMessage());
-			}
+			final Channel chan = irc.getState().getChannel(line.getArguments());
+			irc.invokeServerListeners()
+				.onTopic(irc, chan, chan.updateUser(line.getSender(), false), line.getMessage());
 		} else if (line.getCommand().equals("NICK")) {
 			User newUser;
 			if (line.hasMessage()) {
@@ -207,17 +191,14 @@ final class IrcParser {
 			if (line.getSender().isUs()) {
 				irc.getState().getClient().setNick(newUser.getNick());
 			}
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				it.next().onNick(irc, line.getSender(), newUser);
-			}
+			irc.invokeServerListeners().onNick(irc, line.getSender(), newUser);
 		} else if (line.getCommand().equals("INVITE")) {
 			// someone was invited
 			final String[] args = line.getArgumentsArray();
 			if ((args.length >= 2) && (line.getMessage() == null)) {
 				final Channel channel = irc.createChannel(args[1]);
-				for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-					it.next().onInvite(irc, line.getSender(), new User(args[0], irc), channel);
-				}
+				irc.invokeServerListeners()
+					.onInvite(irc, line.getSender(), new User(args[0], irc), channel);
 			}
 		} else {
 			if (irc.getAdvancedListener() != null) {
@@ -236,9 +217,8 @@ final class IrcParser {
 		final String[] args = line.getArgumentsArray();
 		if ((args.length >= 2) && (Channel.CHANNEL_PREFIX.indexOf(args[0].charAt(0)) >= 0)) {
 			// general mode event listener
-			for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-				it.next().onMode(irc, irc.getState().getChannel(args[0]), line.getSender(), line.getArguments().substring(args[0].length() + 1));
-			}
+			irc.invokeServerListeners()
+				.onMode(irc, irc.getState().getChannel(args[0]), line.getSender(), line.getArguments().substring(args[0].length() + 1));
 			if ((args.length >= 3)) {
 				final Channel channel = irc.getState().getChannel(args[0]);
 				final String mode = args[1];
@@ -253,61 +233,51 @@ final class IrcParser {
 						// voice or devoice
 						irc.askNames(channel);
 						if (enable) {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onVoice(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onVoice(irc, channel, line.getSender(), irc.createUser(args[x]));
 						} else {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onDeVoice(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onDeVoice(irc, channel, line.getSender(), irc.createUser(args[x]));
 						}
 					} else if (current == User.MODE_ADMIN) {
 						// admin or deadmin
 						irc.askNames(channel);
 						if (enable) {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onAdmin(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onAdmin(irc, channel, line.getSender(), irc.createUser(args[x]));
 						} else {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onDeAdmin(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onDeAdmin(irc, channel, line.getSender(), irc.createUser(args[x]));
 						}
 					} else if (current == User.MODE_OPERATOR) {
 						// op or deop
 						irc.askNames(channel);
 						if (enable) {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onOp(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onOp(irc, channel, line.getSender(), irc.createUser(args[x]));
 						} else {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onDeOp(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onDeOp(irc, channel, line.getSender(), irc.createUser(args[x]));
 						}
 					} else if (current == User.MODE_HALF_OP) {
 						// halfop or dehalfop
 						irc.askNames(channel);
 						if (enable) {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onHalfop(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onHalfop(irc, channel, line.getSender(), irc.createUser(args[x]));
 						} else {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onDeHalfop(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onDeHalfop(irc, channel, line.getSender(), irc.createUser(args[x]));
 						}
 					} else if (current == User.MODE_FOUNDER) {
 						// founder or defounder
 						irc.askNames(channel);
 						if (enable) {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onFounder(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onFounder(irc, channel, line.getSender(), irc.createUser(args[x]));
 						} else {
-							for (final Iterator<ModeListener> it = irc.getModeListeners(); it.hasNext();) {
-								it.next().onDeFounder(irc, channel, line.getSender(), irc.createUser(args[x]));
-							}
+							irc.invokeModeListeners()
+								.onDeFounder(irc, channel, line.getSender(), irc.createUser(args[x]));
 						}
 					}
 				}
@@ -324,9 +294,8 @@ final class IrcParser {
 	protected void parseNumeric(final IrcConnection irc, final IrcPacket line) {
 		switch (line.getNumericCommand()) {
 			case IrcPacket.RPL_TOPIC:
-				for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-					it.next().onTopic(irc, irc.getState().getChannel(line.getArgumentsArray()[1]), null, line.getMessage());
-				}
+				irc.invokeServerListeners()
+					.onTopic(irc, irc.getState().getChannel(line.getArgumentsArray()[1]), null, line.getMessage());
 				break;
 			case IrcPacket.RPL_NAMREPLY:
 				final String[] arguments = line.getArgumentsArray();
@@ -356,9 +325,7 @@ final class IrcParser {
 				if (this.buffer != null) {
 					final String motd = this.buffer.toString();
 					this.buffer = null;
-					for (final Iterator<ServerListener> it = irc.getServerListeners(); it.hasNext();) {
-						it.next().onMotd(irc, motd);
-					}
+					irc.invokeServerListeners().onMotd(irc, motd);
 				}
 				break;
 			case IrcPacket.RPL_BOUNCE:


### PR DESCRIPTION
This fixes issues when a Listener implementation throws an exception, causing other listeners (and possibly more logic) to not be handled correctly.  Thus making it more error tolerant.  In addition it will make invoking the listeners asynchronously earlier later.
This required the addition of the threadly library as a dependency (which I plan to use in other places more later as well, once I do more threading based changes)

I am still in progress in switching the networking code to be non-blocking and to use a thread pool.  But I thought I would show these changes before I finish those (I am not sure when I will finish, but it wont be today)...that way you can see them bit by bit as well, instead of a massive pull request.

Let me know if you have any thoughts, thanks.
